### PR TITLE
Django Msg Class Port

### DIFF
--- a/app/api/views/scores.py
+++ b/app/api/views/scores.py
@@ -5,6 +5,7 @@ from django.http import HttpResponseNotFound, HttpResponseForbidden, JsonRespons
 
 from core.models import DateRange, WidgetInstance
 from util.logging.session_play import SessionPlay
+from util.message_util import MsgUtil
 from util.scoring.scoring_util import ScoringUtil
 from util.widget.validator import ValidatorUtil
 
@@ -23,7 +24,7 @@ class ScoresApi:
 
         # Verify body params
         if not instance_id or not ValidatorUtil.is_valid_hash(instance_id):
-            return HttpResponseNotFound()  # TODO: was Msg::invalid_input(instance_id)
+            return MsgUtil.create_invalid_input_msg(msg=str(instance_id))
 
         # Grab context ID
         context_id = None
@@ -43,7 +44,7 @@ class ScoresApi:
         if not instance:
             return HttpResponseNotFound()
         if not instance.playable_by_current_user():
-            return HttpResponseForbidden()  # TODO: was Msg::no_login()
+            return MsgUtil.create_no_login_msg()
 
         # Get scores and return
         scores = ScoringUtil.get_instance_score_history(instance, context_id)
@@ -65,14 +66,14 @@ class ScoresApi:
         play_id = json_body.get("playId")
 
         if not instance_id or not ValidatorUtil.is_valid_hash(instance_id):
-            return HttpResponseNotFound()  # TODO: Was Msg::invalid_input(instance_id)
+            return MsgUtil.create_invalid_input_msg(msg=str(instance_id))
 
         # Get widget instance and validate user
         instance = WidgetInstance.objects.filter(pk=instance_id).first()
         if not instance:
             return HttpResponseNotFound()
         if not instance.playable_by_current_user():
-            return HttpResponseForbidden()  # TODO: was Msg::no_login
+            return MsgUtil.create_no_login_msg()
 
         scores = ScoringUtil.get_guest_instance_score_history(instance, play_id)
         # TODO: better serializing
@@ -98,7 +99,7 @@ class ScoresApi:
             if not ValidatorUtil.is_valid_hash(preview_inst_id):
                 return HttpResponseBadRequest  # TODO: better error reporting
             if False:  # TODO: \Service_User::verify_session() !== true
-                return HttpResponseForbidden()  # TODO was Msg::no_login()
+                return MsgUtil.create_no_login_msg()
 
             # TODO: look at php
         else:
@@ -107,7 +108,7 @@ class ScoresApi:
             if not session_play:
                 return HttpResponseNotFound()  # TODO better error reporting
             if not session_play.data.instance.playable_by_current_user():
-                return HttpResponseForbidden()  # TODO was Msg::no_login()
+                return MsgUtil.create_no_login_msg()
 
             return JsonResponse(ScoringUtil.get_play_details(session_play))
 
@@ -119,14 +120,14 @@ class ScoresApi:
         instance_id = json_body.get("instanceId")
         include_storage_data = json_body.get("includeStorageData", False)
         if not ValidatorUtil.is_valid_hash(instance_id):
-            return HttpResponseNotFound()  # TODO: was msg::invalid_input
+            return MsgUtil.create_invalid_input_msg(msg=str(instance_id))
 
         # Get widget instance and verify playable by user
         instance = WidgetInstance.objects.filter(pk=instance_id).first()
         if not instance:
             return HttpResponseNotFound()
         if not instance.playable_by_current_user():
-            return HttpResponseForbidden()  # TODO was msg::no_login
+            return MsgUtil.create_no_login_msg()
 
         # Get the score distributions and summaries per semester
         # TODO: these 2 queries seem to be slow (up to 3sec in php!) - maybe they'll perform faster in

--- a/app/api/views/sessions.py
+++ b/app/api/views/sessions.py
@@ -5,6 +5,7 @@ from django.http import JsonResponse, HttpResponseBadRequest, HttpResponseNotFou
 from core.models import WidgetInstance
 from util.logging.session_logger import SessionLogger
 from util.logging.session_play import SessionPlay
+from util.message_util import MsgUtil
 from util.widget.validator import ValidatorUtil
 
 
@@ -45,12 +46,10 @@ class SessionsApi:
 
         # Validate request params
         if not play_id or (not preview_instance_id and not ValidatorUtil.is_valid_long_hash(play_id)):
-            # TODO better error reporting, was originally Msg:invalid_input(play_id)
-            return HttpResponseBadRequest()
+            return MsgUtil.create_invalid_input_msg(msg=play_id)
 
         if not logs or not isinstance(logs, list):
-            # TODO: better error reporting, was originally Msg::invalid_input('missing log array')
-            return HttpResponseBadRequest()
+            return MsgUtil.create_invalid_input_msg(msg="Missing log array")
 
         # Save logs
         if preview_instance_id:
@@ -74,14 +73,14 @@ class SessionsApi:
             # Confirm user session for real play
             instance = session_play.data.instance
             if not instance.playable_by_current_user():
-                return HttpResponseForbidden()  # TODO was Msg::no_login
+                return MsgUtil.create_no_login_msg()
             # if not instance.guest_access and TODO: self::session_play_verify($play_id) !== true
-            #     return Msg::no_login();
+            #     return MsgUtil.create_no_login_msg()
 
             # Validate session play
             is_valid = session_play.validate()
             if not is_valid:
-                return HttpResponseNotFound()  # TODO: was Msg::invalid_input('invalid play session')
+                return MsgUtil.create_invalid_input_msg(msg="Invalid play session")
 
             # Store
             SessionLogger.store_log_array(session_play, logs)

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -2,6 +2,7 @@ from django.http import HttpResponseNotFound, HttpResponseServerError
 from django.shortcuts import render
 from django.views.generic import TemplateView
 from core.models import WidgetInstance, Widget
+from core.views.main import get_dark_mode
 from util.logging.session_play import SessionPlay
 
 
@@ -18,7 +19,8 @@ class WidgetDetailView(TemplateView):
                 "BASE_URL": "http://localhost/",
                 "WIDGET_URL": "http://localhost/widget/",
                 "STATIC_CROSSDOMAIN": "http://localhost/",
-            }
+            },
+            **get_dark_mode(self.request),
         }
         return context
 

--- a/app/util/message_util.py
+++ b/app/util/message_util.py
@@ -1,0 +1,72 @@
+# Util class for creating messages for API errors. Returns JsonResponses that can be
+# directly passed back from the endpoint. The front-end will detect these errors and
+# display or handle them.
+from enum import Enum
+
+from django.http import JsonResponse
+
+
+class MsgType(Enum):
+    ERROR = "error"
+    NOTICE = "notice"
+    WARN = "warn"
+
+
+class MsgUtil:
+    @staticmethod
+    def _create(
+        title: str, msg: str, msg_type: MsgType = MsgType.ERROR, halt: bool = False, status: int = 403
+    ) -> JsonResponse:
+        return JsonResponse({
+            "msg": msg,
+            "title": title,
+            "type": msg_type.value,
+            "halt": halt,
+        }, status=status)
+
+    @staticmethod
+    def create_invalid_input_msg(title: str = "Validation Error", msg: str = "") -> JsonResponse:
+        return MsgUtil._create(title, msg, msg_type=MsgType.ERROR, halt=True)
+
+    @staticmethod
+    def create_no_login_msg(
+        title="Invalid Login",
+        msg="You have been logged out, and must login again to continue",
+    ):
+        return MsgUtil._create(title, msg, MsgType.ERROR, True)
+        # TODO set_flash, see php
+
+    @staticmethod
+    def create_no_perm_msg(
+        title: str = "Permission Denied",
+        msg: str = "You do not have permission to access the requested content",
+    ) -> JsonResponse:
+        return MsgUtil._create(title, msg, MsgType.WARN, False, 401)
+
+    @staticmethod
+    def create_student_collab_msg(
+        title="Share Not Allowed",
+        msg="Students cannot be added as collaborator to widgets that have guest access disabled"
+    ) -> JsonResponse:
+        return MsgUtil._create(title, msg, MsgType.ERROR, False, 401)
+
+    @staticmethod
+    def create_failure_msg(
+        title: str = "Action Failed",
+        msg: str = "The requested action could not be completed",
+    ):
+        return MsgUtil._create(title, msg, MsgType.ERROR, False, 403)
+
+    @staticmethod
+    def create_not_found_msg(
+        title="Not Found",
+        msg="The requested content could not be found",
+    ) -> JsonResponse:
+        return MsgUtil._create(title, msg, MsgType.ERROR, False, 404)
+
+    @staticmethod
+    def create_expired_msg(
+        title="Expired",
+        msg="The requested content has been expired and is no longer available",
+    ):
+        return MsgUtil._create(title, msg, MsgType.ERROR, False, 410)

--- a/app/util/scoring/scoring_util.py
+++ b/app/util/scoring/scoring_util.py
@@ -34,8 +34,6 @@ class ScoringUtil:
             # TODO: user_id =
         ).first()
 
-        ScoringUtil.get_instance_score_history()
-
         return result.extra_attempts if result else 0
 
     @staticmethod

--- a/app/util/scoring/scoring_util.py
+++ b/app/util/scoring/scoring_util.py
@@ -34,6 +34,8 @@ class ScoringUtil:
             # TODO: user_id =
         ).first()
 
+        ScoringUtil.get_instance_score_history()
+
         return result.extra_attempts if result else 0
 
     @staticmethod


### PR DESCRIPTION
Ports over the `Msg` class from PHP Materia to Django. `MsgUtil` creates `JsonResponse`s for error states that occur on the API endpoints that the frontend can parse and understand.

- All `Msg` functions ported over
- Replaced all `# TODO`s that mentioned something along the lines of `used to be Msg` to use the new `MsgUtil` class
- `MsgUtils`'s functions names are a tad bit more descriptive (`MsgUtil.create_no_login_msg()` as opposed to `Msg.no_login()`)
- Some additional work needs to be done for finding a suitable replacement for `get_flash` and `set_flash`, which `Msg.no_login` used.
  - No direct replacement seems to exist in Django, except for an old and deprecated plugin someone wrote.
  - Django _does_ has its Messages framework, but it seems a lot more suited for rendering one-time messages using it's templating engine (something that's hard to do since we're really just using React everywhere)
    - And while we can access all of the messages set via Python, once we read them, they are gone. There is also no way to 'key' messages and get them by that key - we'd have to read the whole array of messages just for find the one we're looking for, expiring all the messages in the process.
  - Simplest solution I can think of is to just set variables on the user's session, and delete them after we read them where applicable.
