### PR TITLE
Allow `make` commands to optionally avoid creating temporary containers.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,13 +125,13 @@ lint-backend: ## Run backend code formatter and linter
 	@if pyenv virtualenvs | grep materia-local >> /dev/null; then \
 		black ./app/**/*.py; \
 	else \
-		$(DOCKER_COMPOSE) run --rm python black .; \
+		$(MAKE) run-docker-command black .; \
 	fi
 lint-backend-check: ## Run backend code formatter and linter in check mode
 	@if pyenv virtualenvs | grep materia-local >> /dev/null; then \
 		black ./app/**/*.py --check; \
 	else \
-		$(DOCKER_COMPOSE) run --rm python black . --check; \
+		$(MAKE) run-docker-command black . --check; \
 	fi
 
 lint-frontend: ## Run frontend linter

--- a/Makefile
+++ b/Makefile
@@ -150,10 +150,9 @@ migrate-app: ## Run migrations for a specific app to a specific point. Example: 
 migrate-app-to: ## Run migrations for a specific app to a specific point. Example: make migrate-to app=core migration=zero
 	@$(MAKE) run-docker-command DOCKER_COMMAND="python manage.py migrate $(app) $(migration)"
 
-# repeating container detection since these functions have to run in interactive TTY mode, unlike the rest
-bash: ## Start a Bash session in the application's Python container if it's running
+bash: ## Start a Bash session in the application's Python container
 	@$(MAKE) run-docker-command IT_MODE=1 DOCKER_COMMAND="bash"
-shell: ## Run shell in Django context
+shell: ## Run a Python shell in the Django context
 	@$(MAKE) run-docker-command IT_MODE=1 DOCKER_COMMAND="python manage.py shell"
 
 manage: ## Run Django management command. Example: make manage command="showmigrations"

--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Several `make` commands are provided for your convenience:
  * `make dev-check` will check to ensure that the requisite tools `pyenv` and `pyenv-virtualenv` are installed, as well as the required version of Python. If any of the prerequisites are unavailable, you will be notified.
  * `make dev-setup` will, assuming all requirements in `dev-check` pass, automatically create a local dev environment with `pyenv` and `virtualenv`, install all necessary Python packages, and install pre-commit hooks.
 
+Run `make help` to see a full list of commands that will simplify linting your code, running migrations, or starting interactive shell sessions within the container.
+
 ---
 
 View the [Materia Docs](http://ucfopen.github.io/Materia-Docs/) for info on installing, using, and developing Materia and widgets.


### PR DESCRIPTION
Modifies most `make` commands to use `pyenv-virtualenv` dev environments and/or running Docker containers where possible instead of always making new throwaway containers.