### PR TITLE
removes setting is_complete in scoringApi and handles it in update me…

### DIFF
--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -168,14 +168,6 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                 if not is_preview:
                     session = SessionPlay(pk)
                     session.update_elapsed()
-                    play = session.data
-
-                    if not play.is_complete:
-                        if Log.objects.filter(
-                            play_id=play.id, log_type__iexact="WIDGET_END"
-                        ).exists():
-                            play.is_complete = True
-                            play.save()
 
                 else:
                     # put preview logs in session

--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -161,15 +161,24 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                         game_time=log.get("game_time", -1),
                     )
 
-                    # only plays are saved to the db - previews are stored in request session (see below)
+                    # only plays are saved to the db previews are stored in request session
                     if not is_preview:
                         log_model.save()
-                    # TODO put preview logs in session
 
                 if not is_preview:
                     session = SessionPlay(pk)
                     session.update_elapsed()
+                    play = session.data
+
+                    if not play.is_complete:
+                        if Log.objects.filter(
+                            play_id=play.id, log_type__iexact="WIDGET_END"
+                        ).exists():
+                            play.is_complete = True
+                            play.save()
+
                 else:
+                    # put preview logs in session
                     preview_play_id = update_serializer.validated_data[
                         "preview_play_id"
                     ]

--- a/app/scoring/manager.py
+++ b/app/scoring/manager.py
@@ -118,9 +118,6 @@ class ScoringUtil:
         )
         play = session_play.data
         play.percent = score_module.calculated_percent
-        if not session_play.is_preview:
-            play.is_complete = True
-            play.save()
 
         qset = instance.get_qset_for_play(session_play.data.id)
         from core.serializers import QuestionSetSerializer
@@ -173,10 +170,6 @@ class ScoringUtil:
         )
         play = session_play.data
         play.percent = score_module.calculated_percent
-        # dont save the play if its a preview
-        if not session_play.is_preview:
-            play.is_complete = True
-            play.save()
 
         widget_instance.get_qset(widget_instance.id, session_play.data.created_at)
         details["qset"] = (
@@ -227,9 +220,6 @@ class ScoringUtil:
         )
         play = session_play.data
         play.percent = score_module.calculated_percent
-        if not session_play.is_preview:
-            play.is_complete = True
-            play.save()
 
         if session_play.is_preview:
             qset = instance.get_qset_for_play(play_id, True)

--- a/app/scoring/manager.py
+++ b/app/scoring/manager.py
@@ -118,6 +118,10 @@ class ScoringUtil:
         )
         play = session_play.data
         play.percent = score_module.calculated_percent
+        if not session_play.is_preview:
+            if score_module.finished:
+                play.is_complete = True
+                play.save()
 
         qset = instance.get_qset_for_play(session_play.data.id)
         from core.serializers import QuestionSetSerializer
@@ -170,6 +174,11 @@ class ScoringUtil:
         )
         play = session_play.data
         play.percent = score_module.calculated_percent
+        # dont save the play if its a preview
+        if not session_play.is_preview:
+            if score_module.finished:
+                play.is_complete = True
+                play.save()
 
         widget_instance.get_qset(widget_instance.id, session_play.data.created_at)
         details["qset"] = (
@@ -220,6 +229,10 @@ class ScoringUtil:
         )
         play = session_play.data
         play.percent = score_module.calculated_percent
+        if not session_play.is_preview:
+            if score_module.finished:
+                play.is_complete = True
+                play.save()
 
         if session_play.is_preview:
             qset = instance.get_qset_for_play(play_id, True)


### PR DESCRIPTION
This PR address issue #65 and moves the logic of setting `is_complete` in the update method of `app/api/views/playessions.py` whilst removing it from ScoringApi. 