### PR TITLE
API, perms, playsessions, and score screen changes

### DIFF
--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -8,9 +8,6 @@ from core.serializers import (
     PlayLogUpdateSerializer,
     PlaySessionCreateSerializer,
     PlaySessionSerializer,
-    PlaySessionStudentViewSerializer,
-    PlaySessionWithExtrasSerializer,
-    PlaySessionWithExtraUserInfoSerializer,
 )
 from core.services import WidgetPlayInitService
 from django.db.models import Max
@@ -85,8 +82,11 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
         serializer = self.get_serializer(queryset, many=True)
         return Response(serializer.data)
 
-    # we only need extras (widget name, inst name) when on the profile page
-    def get_serializer_class(self):
+    def get_serializer(self, *args, **kwargs):
+        """
+        PlaySessionSerializer operates on a number of kwargs to determine what fields to use
+        To pass them in, we implement get_serializer and manually append each kwarg
+        """
         inst_id = self.request.query_params.get("inst_id")
         include_user_info = ValidatorUtil.validate_bool(
             self.request.query_params.get("include_user_info"), default=False
@@ -95,33 +95,21 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
             self.request.query_params.get("include_activity"), default=False
         )
 
-        if inst_id and include_user_info:
-            try:
-                instance = WidgetInstance.objects.get(pk=inst_id)
-            except WidgetInstance.DoesNotExist:
-                # logger.error(f"WidgetInstance {inst_id} does not exist")
-                # perhaps we should retunr the default seralizer instead
-                logger.warning(
-                    f"[get_serializer_class] WidgetInstance '{inst_id}' not found. "
-                    f"Falling back to PlaySessionSerializer."
-                )
-                # PR TODO: Rework the method entirely to filter by method first(after this gets merged in)
-                return PlaySessionSerializer
-            if instance and instance.guest_access:
-                # print("Widget is in guest mode, hiding user info")
-                return PlaySessionSerializer
-            else:
-                # print("Widget is NOT in guest mode, showing user info")
-                return PlaySessionWithExtraUserInfoSerializer
+        kwargs["is_student_view"] = inst_id and PermManager.user_is_student(
+            self.request.user
+        )
+        kwargs["include_activity"] = bool(include_activity)
+        kwargs["include_user_info"] = bool(include_user_info) and not (
+            inst_id and WidgetInstance.objects.filter(pk=inst_id).first().guest_access
+        )
 
-        elif inst_id and PermManager.user_is_student(self.request.user):
-            return PlaySessionStudentViewSerializer
+        return super().get_serializer(*args, **kwargs)
 
-        elif include_activity:
-            return PlaySessionWithExtrasSerializer
-
-        else:
-            return PlaySessionSerializer
+    def get_serializer_class(self):
+        """
+        get_serializer_class must be explicitly defined so get_serializer works as expected
+        """
+        return PlaySessionSerializer
 
     def create(self, request):
         serializer = PlaySessionCreateSerializer(
@@ -141,16 +129,18 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                     if validated["instance"].guest_access is False
                     else None
                 )
+
+                # disallow plays for non-playable widget engines
+                if not validated["instance"].widget.is_playable:
+                    return MsgBuilder.failure(
+                        "Failed to Create Play Session", "This widget is not playable."
+                    ).as_drf_response()
+
+                # init the new play
                 new_play = WidgetPlayInitService.init_play(
                     request, validated["instance"], user
                 )
-
-                # this is where the desired error handling from session_play gets handled
                 if not new_play.id:
-                    logger.warning(
-                        f"[Playsessions] Failed to start play session for instance"
-                        f"{validated["instance"].id} and user {user}"
-                    )
                     return MsgBuilder.failure(
                         "Failed to Create Play Session",
                         "There was an error starting your play session. Please try again.",
@@ -196,6 +186,13 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
 
                 if not is_preview:
                     play = LogPlay.objects.get(pk=pk)
+                    self.check_object_permissions(request, play)
+
+                    if not play.is_valid:
+                        return MsgBuilder.failure(
+                            msg="This play is no longer valid."
+                        ).as_drf_response()
+
                     play.update_elapsed()
 
                     score_module = ScoreModuleFactory.create_score_module(

--- a/app/api/views/scores.py
+++ b/app/api/views/scores.py
@@ -12,6 +12,7 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from scoring.module_factory import ScoreModuleFactory
 from util.message_util import MsgBuilder
+from util.perm_manager import PermManager
 from util.semester_util import SemesterUtil
 
 logger = logging.getLogger(__name__)
@@ -48,15 +49,19 @@ class ScoresView(APIView):
             """
             access perms require either:
             the user id in the API request matches the current user OR
-            the current user has authorship permissions to the instance
+            the current user has authorship permissions to the instance OR
+            the current user is a support user
             """
             if (
                 request.user.id != user.id
                 and not instance.permissions.filter(user=request.user).exists()
+                and not PermManager.is_superuser_or_elevated(request.user)
             ):
                 return MsgBuilder.no_perm().as_drf_response()
 
-            plays = LogPlay.objects.filter(user=user, instance=instance)
+            plays = LogPlay.objects.filter(
+                user=user, instance=instance, is_complete=True
+            )
 
             if validated.get("context"):
                 plays = plays.filter(context_id=context)
@@ -180,6 +185,7 @@ class ScoresDetailView(APIView):
                     user_id != play_user_id
                     and play_user_id is not None
                     and not play.instance.permissions.filter(user=request.user).exists()
+                    and not PermManager.is_superuser_or_elevated(request.user)
                 ):
                     return MsgBuilder.no_perm().as_drf_response()
 

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -74,7 +74,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         # score distribution needs to be accessible to anyone who can play an instance
         # this either requires authentication (for normal instances)
         # or public visibility (for guest instances)
-        elif self.action == "scores":
+        elif self.action == "performance":
             permission_classes = [IsAuthenticatedOrGuestMode]
 
         # must have (any) access to instance or elevated perms
@@ -282,7 +282,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
 
     # TODO should this be under /instances or /scores ?
     @action(detail=True, methods=["get"])
-    def scores(self, request, pk=None):
+    def performance(self, request, pk=None):
         instance = self.get_object()
 
         logs_for_user = (

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -491,6 +491,7 @@ class LogPlay(models.Model):
 
     def set_complete(self, score, possible, percent):
         self.is_complete = True
+        self.is_valid = False
         self.score = score
         self.score_possible = possible
         self.percent = percent if percent <= 100 else 100

--- a/app/core/permissions.py
+++ b/app/core/permissions.py
@@ -171,6 +171,9 @@ class PlaySessionInstancePermissions(permissions.BasePermission):
         if not isinstance(obj, LogPlay):
             return False
 
+        if obj.user != request.user:
+            return False
+
         if request.user and request.user.is_authenticated:
             return True
 

--- a/app/core/serializers.py
+++ b/app/core/serializers.py
@@ -553,20 +553,31 @@ class PlaySessionCreateSerializer(serializers.Serializer):
 
 # play session model (kinda) serializer (outbound)
 class PlaySessionSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = LogPlay
-        fields = [
+    inst_name = serializers.CharField(source="instance.name", read_only=True)
+    widget_name = serializers.CharField(source="instance.widget.name", read_only=True)
+    widget_icon = serializers.SerializerMethodField()
+    user = UserSerializer(read_only=True)
+
+    def get_widget_icon(self, play):
+        return f"{play.instance.widget.id}-{play.instance.widget.clean_name}{os.sep}"
+
+    def __init__(self, *args, **kwargs):
+        is_student_view = kwargs.pop("is_student_view", False)
+        include_user_info = kwargs.pop("include_user_info", False)
+        include_activity = kwargs.pop("include_activity", False)
+
+        super().__init__(*args, **kwargs)
+
+        field_set = [
             "id",
             "instance",
             "is_valid",
-            "user_id",
             "is_complete",
             "score",
             "score_possible",
             "percent",
             "elapsed",
             "qset_id",
-            # "environment_data",
             "auth",
             "referrer_url",
             "context_id",
@@ -574,14 +585,19 @@ class PlaySessionSerializer(serializers.ModelSerializer):
             "created_at",
         ]
 
+        if not is_student_view:
+            field_set.append("user_id")
 
-# play session model (kinda) with inst and widget names included (outbound)
-# these include hits to other tables, so only include them if specifically needed
-class PlaySessionWithExtrasSerializer(serializers.ModelSerializer):
+        if include_activity:
+            field_set.extend(["inst_name", "widget_name", "widget_icon"])
 
-    inst_name = serializers.CharField(source="instance.name", read_only=True)
-    widget_name = serializers.CharField(source="instance.widget.name", read_only=True)
-    widget_icon = serializers.SerializerMethodField()
+        if include_user_info:
+            field_set.append("user")
+
+        allowed = set(field_set)
+        existing = set(self.fields)
+        for field_name in existing - allowed:
+            self.fields.pop(field_name)
 
     class Meta:
         model = LogPlay
@@ -596,7 +612,6 @@ class PlaySessionWithExtrasSerializer(serializers.ModelSerializer):
             "percent",
             "elapsed",
             "qset_id",
-            # "environment_data",
             "auth",
             "referrer_url",
             "context_id",
@@ -605,59 +620,7 @@ class PlaySessionWithExtrasSerializer(serializers.ModelSerializer):
             "inst_name",
             "widget_name",
             "widget_icon",
-        ]
-
-    def get_widget_icon(self, play):
-        return f"{play.instance.widget.id}-{play.instance.widget.clean_name}{os.sep}"
-
-
-# play session model; do not include user_id
-class PlaySessionStudentViewSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = LogPlay
-        fields = [
-            "id",
-            "instance",
-            "is_valid",
-            "is_complete",
-            "score",
-            "score_possible",
-            "percent",
-            "elapsed",
-            "qset_id",
-            # "environment_data",
-            "auth",
-            "referrer_url",
-            "context_id",
-            "semester_id",
-            "created_at",
-        ]
-
-
-# play session model; include extra info about user
-class PlaySessionWithExtraUserInfoSerializer(serializers.ModelSerializer):
-    user = UserSerializer(read_only=True)
-
-    class Meta:
-        model = LogPlay
-        fields = [
-            "id",
-            "instance",
-            "is_valid",
-            "is_complete",
-            "score",
-            "score_possible",
-            "percent",
-            "elapsed",
-            "qset_id",
-            # "environment_data",
-            "auth",
-            "referrer_url",
-            "context_id",
-            "semester_id",
-            "created_at",
             "user",
-            "user_id",
         ]
 
 

--- a/app/core/views/scores.py
+++ b/app/core/views/scores.py
@@ -6,7 +6,6 @@ from django.http import (
     HttpRequest,
     HttpResponseBadRequest,
     HttpResponseNotFound,
-    HttpResponseRedirect,
 )
 from django.views.generic import TemplateView
 from util.context_util import ContextUtil
@@ -14,13 +13,10 @@ from util.context_util import ContextUtil
 
 class ScoresView(MateriaLoginMixin, TemplateView):
     template_name = "react.html"
-    is_preview = False
     allow_all_by_default = True
 
     def get(self, request, *args, **kwargs):
         widget_instance_id = kwargs.get("widget_instance_id")
-        token = kwargs.get("token")
-        is_embedded = kwargs.get("is_embedded", False)
 
         instance = WidgetInstance.objects.filter(pk=widget_instance_id).first()
         if not instance:
@@ -41,9 +37,6 @@ class ScoresView(MateriaLoginMixin, TemplateView):
             css_resources=settings.CSS_GROUPS["scores"],
             js_globals={
                 "USER_ID": request.user.id,
-                "IS_EMBEDDED": is_embedded,
-                "IS_PREVIEW": self.is_preview,
-                "LAUNCH_TOKEN": token,
             },
             request=self.request,
         )
@@ -62,7 +55,7 @@ class ScoresViewSingle(MateriaLoginMixin, TemplateView):
         # Get url args
         play_id = kwargs.get("play_id")
         widget_instance_id = kwargs.get("widget_instance_id")
-        token = self.kwargs.get("token")
+        token = self.kwargs.get("token")  # TODO verify if token is visible here
 
         # Grab and verify play
         play = LogPlay.objects.get(pk=play_id)
@@ -71,37 +64,24 @@ class ScoresViewSingle(MateriaLoginMixin, TemplateView):
         if play.instance.id != widget_instance_id:
             return HttpResponseBadRequest()
 
-        redirect = None
-        is_embedded = False
+        # TODO
+        # Revisit this redirect: this event trigger was associated LTI 1.1
 
         # Allow event listeners to redirect users
         # This is mostly to redirect them to failure status pages
-        # TODO event trigger here - see php
         # $results = \Event::trigger('before_single_score_review',
         # ['play_id' => $play_id, 'content_id' => $play->context_id], 'array');
 
-        results = []
-        for result in results:
-            # Allow events to redirect
-            if "redirect" in result:
-                redirect = result["redirect"]
-            if "is_embedded" in result:
-                is_embedded = result["is_embedded"]
+        # if redirect:
+        #     return HttpResponseRedirect(redirect)
 
-        if redirect:
-            return HttpResponseRedirect(redirect)
-
-        context = _get_context_data(
-            request, widget_instance_id, is_embedded, False, token
-        )
+        context = _get_context_data(request, widget_instance_id, token)
         return self.render_to_response(context)
 
 
 def _get_context_data(
     request: HttpRequest,
     widget_instance_id: str,
-    is_embedded: bool = False,
-    is_preview: bool = False,
     token: str = None,
 ) -> dict:
     # Get widget instance
@@ -115,12 +95,11 @@ def _get_context_data(
 
     # Set up context and return
     js_globals = {
-        "IS_EMBEDDED": is_embedded,
-        "IS_PREVIEW": is_preview,
+        "USER_ID": request.user.id,
     }
 
     if token:
-        js_globals["LAUNCH_TOKEN"] = token
+        js_globals["LTI_TOKEN"] = token
 
     return ContextUtil.create(
         title="Score Results",

--- a/app/materia/urls.py
+++ b/app/materia/urls.py
@@ -123,8 +123,8 @@ urlpatterns = [
     ),
     # Scores
     path(
-        "scores/preview/<slug:widget_instance_id>/",
-        ScoresView.as_view(is_preview=True),
+        "scores/preview/<slug:widget_instance_id>/<slug:preview_id>/",
+        ScoresView.as_view(),
         name="preview scores",
     ),
     path(

--- a/app/scoring/module.py
+++ b/app/scoring/module.py
@@ -144,9 +144,6 @@ class ScoreModule(ABC):
         """calculate final score percentage"""
         global_mod = sum(self.global_modifiers)
 
-        # sum up all the scores
-        self.verified_score = sum(self.scores.values())
-
         if self.total_questions > 0:
             points = self.verified_score + global_mod * self.total_questions
             self.calculated_percent = points / self.total_questions

--- a/src/components/score-details.jsx
+++ b/src/components/score-details.jsx
@@ -4,91 +4,89 @@ import ScoreGraphic from './score-graphic'
 const ScoreDetails = ({details, complete}) => {
 
 	let detailsRender = []
-	details?.forEach((detail, i) => {
-		let detailsTableRows = []
-		let detailsHeaders = []
-		detail.table.forEach((row, j) => {
-			let detailsTableData = []
-			if (row.graphic != 'none') {
+	let detailsTableRows = []
+	let detailsHeaders = []
 
-				let greyMode = false
-				const index = j + 1
-				const percent = row.score / 100
+	details?.table.forEach((row, j) => {
+		let detailsTableData = []
+		if (row.graphic != 'none') {
 
-				let scoreGraphic = null
+			let greyMode = false
+			const index = j + 1
+			const percent = row.score / 100
 
-				switch (row.graphic) {
-					case 'modifier':
-						greyMode = row.score === 0
-						scoreGraphic = <ScoreGraphic type="modifier" width={50} height={50} set={i} number={index} percent={percent} greyMode={greyMode} />
-						break
-					case 'final':
-						scoreGraphic = <ScoreGraphic type="final" width={50} height={50} set={i} number={index} percent={percent} greyMode={greyMode} />
-						break
-					case 'score':
-						greyMode = row.score === -1
-						scoreGraphic = <ScoreGraphic type="score" width={50} height={50} set={i} number={index} percent={percent} greyMode={greyMode} />
-						break
-				}
+			let scoreGraphic = null
 
-				detailsTableData.push(
-					<td key={`details-index-${index}`} className="index">
-						{scoreGraphic}
-						{row.display_score &&
-							<span>
-								{row.score}{row.symbol}
-							</span>
-						}
-					</td>
-				)
+			switch (row.graphic) {
+				case 'modifier':
+					greyMode = row.score === 0
+					scoreGraphic = <ScoreGraphic type="modifier" width={50} height={50} number={index} percent={percent} greyMode={greyMode} />
+					break
+				case 'final':
+					scoreGraphic = <ScoreGraphic type="final" width={50} height={50} number={index} percent={percent} greyMode={greyMode} />
+					break
+				case 'score':
+					greyMode = row.score === -1
+					scoreGraphic = <ScoreGraphic type="score" width={50} height={50} number={index} percent={percent} greyMode={greyMode} />
+					break
 			}
 
-			row.data.forEach((data, index) => {
-				detailsTableData.push(
-					<td key={`${row.data_style[index]}-${index}`} className={row.data_style[index]}>{data}</td>
-				)
-			})
+			detailsTableData.push(
+				<td key={`details-index-${index}`} className="index">
+					{scoreGraphic}
+					{row.display_score &&
+						<span>
+							{row.score}{row.symbol}
+						</span>
+					}
+				</td>
+			)
+		}
 
+		row.data.forEach((data, index) => {
+			detailsTableData.push(
+				<td key={`${row.data_style[index]}-${index}`} className={row.data_style[index]}>{data}</td>
+			)
+		})
+
+		detailsTableRows.push(
+			<tr key={`details-row-${j + 1}`} className={`${row.style} ${row.feedback != null ? 'has_feedback' : ''}`}>
+				{detailsTableData}
+			</tr>
+		)
+
+		if (row.feedback != null) {
 			detailsTableRows.push(
-				<tr key={`details-row-${j + 1}`} className={`${row.style} ${row.feedback != null ? 'has_feedback' : ''}`}>
-					{detailsTableData}
+				<tr key={`details-feedback-${j + 2}`} className="feedback single_column">
+					<td colSpan={row.data.length + 1}>
+						<p>{row.feedback}</p>
+					</td>
 				</tr>
 			)
+		}
+	})
 
-			if (row.feedback != null) {
-				detailsTableRows.push(
-					<tr key={`details-feedback-${j + 2}`} className="feedback single_column">
-						<td colSpan={row.data.length + 1}>
-							<p>{row.feedback}</p>
-						</td>
-					</tr>
-				)
-			}
-
-		})
-
-		detail.headers.forEach((header, i) => {
-			detailsHeaders.push(
-				<th key={`${header}-${i}`}>{header}</th>
-			)
-		})
-
-		detailsRender.push(
-			<section className={`details ${!complete ? 'incomplete' : ''}`} key={i}>
-				<h1>{detail.title}</h1>
-				<table>
-					<thead>
-						<tr className="details_header">
-							{detailsHeaders}
-						</tr>
-					</thead>
-					<tbody>
-						{detailsTableRows}
-					</tbody>
-				</table>
-			</section>
+	details.headers.forEach((header, i) => {
+		detailsHeaders.push(
+			<th key={`${header}-${i}`}>{header}</th>
 		)
 	})
+
+	detailsRender.push(
+		<section className={`details ${!complete ? 'incomplete' : ''}`} key={1}>
+			<h1>{details.title}</h1>
+			<table>
+				<thead>
+					<tr className="details_header">
+						{detailsHeaders}
+					</tr>
+				</thead>
+				<tbody>
+					{detailsTableRows}
+				</tbody>
+			</table>
+		</section>
+	)
 
 	return (
 		<>

--- a/src/components/score-graphic.jsx
+++ b/src/components/score-graphic.jsx
@@ -1,13 +1,14 @@
 import React, { useRef, useEffect } from 'react'
 
 // renders the graphic displayed for default score screens that represents the score for an individual question
-const ScoreGraphic = ({type, width, height, set, number, percent, greyMode}) => {
+const ScoreGraphic = ({type, width, height, set=0, number, percent, greyMode}) => {
 	
 	const canvasRef = useRef(null)
-	const canvas = canvasRef.current
+
 
 	useEffect(() => {
 
+		const canvas = canvasRef.current
 		if (!canvas) return
 
 		// to make the canvas look good on retina displays, we need to scale it up
@@ -107,7 +108,7 @@ const ScoreGraphic = ({type, width, height, set, number, percent, greyMode}) => 
 			const dpi = window.devicePixelRatio;
 			context.scale(dpi, dpi);
 		}
-	}, [canvas, percent])
+	}, [height, type, percent, number, set])
 	
 	return (
 		<canvas

--- a/src/components/score-page.jsx
+++ b/src/components/score-page.jsx
@@ -3,76 +3,56 @@ import Header from './header'
 import Scores from './scores'
 
 const ScorePage = () => {
-	// get the playId from the url if using /scores/single/:instId/:playId url
-	const res = window.location.pathname.match(/\/scores\/single\/([a-z0-9\-_]+)\/([a-z0-9\-_]+)/i)
-	const single_id = (res && res[2]) || null
 
-	// We don't want users who click the 'View more details' link via an LTI to play again, since at that point
-	// the play will no longer be connected to the LTI details.
-	// This is a cheap way to hide the button:
-	const hidePlayAgain = document.URL.indexOf('details=1') > -1
-	// get widget id from url like https://my-server.com:8080/scores/nLAmG#play-NbmVXrZe9Wzb
-	const split_url = document.URL.match(/^.+\/([a-z0-9]+)\/([a-z0-9-]+)/i)
+	let isSingle = false
+	let isPreview = false
+	let isEmbed = false
+	let instID = null
+	let playID = null
+	let token = null
 
-	let pathIsPreview = false
-	let instId = null
-	let playId = null
-	if (split_url[1] === 'preview') {
-		pathIsPreview = true
-		instId = split_url[2]
-	} else {
-		instId = split_url[1]
-		playId = split_url[2]
-	} // TODO This might be wrong (django rewrite)
+	const urlElements = window.location.pathname.match(/\/scores\/(single\/)?(preview\/)?(embed\/)?([a-z0-9\-_]+)\/([a-z0-9\-_]+)/i)
+	if (urlElements) {
+		isSingle = urlElements[1] == "single/"
+		isPreview = urlElements[2] == "preview/"
+		isEmbed = urlElements[3] == "embed/"
+		instID = urlElements[4]
+		playID = urlElements[5]
+	}
 
-	const previewPlayId = useMemo(() => {
-		let params = new URLSearchParams(document.location.search);
-		return params.get("previewId")
-	}, [])
 
-	// this is only actually set to something when coming from the profile page
-	//const playId = window.location.hash.split('play-')[1]
-
-	const pathIsEmbedded = window.location.pathname.includes('/embed/')
+	const urlParams = new URLSearchParams(window.location.search)
+	token = urlParams.get('token')
 
 	const [state, setState] = useState({
-		instanceID: undefined,
+		instanceID: instID,
 		userID: undefined,
-		playID: undefined,
-		singleID: undefined,
-		sendToken: undefined,
-		isEmbedded: pathIsEmbedded,
-		isPreview: pathIsPreview
+		playID: playID,
+		isEmbedded: isEmbed,
+		isPreview: isPreview,
+		isSingle: isSingle,
+		ready: false
 	})
 
-	// Waits for window values to load from server then sets them
 	useEffect(() => {
 		waitForWindow()
 		.then(() => {
-			if (window.IS_EMBEDDED) document.body.classList.add('embedded')
-
 			setState({
+				...state,
 				userID: window.USER_ID ?? null,
-				instanceID: (instId ? instId : null),
-				playID: playId ? playId : null,
-				singleID: single_id ? single_id : null,
-				sendToken: typeof window.LAUNCH_TOKEN !== 'undefined' && window.LAUNCH_TOKEN !== null ? window.LAUNCH_TOKEN : playId,
-				isEmbedded: window.IS_EMBEDDED == 'true' || window.IS_EMBEDDED == true || pathIsEmbedded ? true : false,
-				isPreview: window.IS_PREVIEW == 'true' || window.IS_PREVIEW == true || pathIsPreview ? true : false,
+				playID: playID,
+				token: token,
+				isEmbedded: isEmbed || !!token,
+				ready: true
 			})
 		})
 	}, [])
 
-	// Used to wait for window data to load
 	const waitForWindow = async () => {
-		while(!window.hasOwnProperty('IS_EMBEDDED')
-		&& !window.hasOwnProperty('USER_ID')
-		&& !window.hasOwnProperty('IS_PREVIEW')
-		&& !window.hasOwnProperty('LAUNCH_TOKEN')) {
+		while(!window.hasOwnProperty('USER_ID')) {
 			await new Promise(resolve => setTimeout(resolve, 500))
 		}
 	}
-
 
 	let headerRender = null
 	if (!state.isEmbedded) {
@@ -80,16 +60,18 @@ const ScorePage = () => {
 	}
 
 	let bodyRender = null
-	if ( state.isPreview !== undefined ) {
-		bodyRender = <Scores instId={state.instanceID}
-		playId={state.playID}
-		single_id={state.singleID}
-		userId={state.userID}
-		send_token={state.sendToken}
+	if (state.ready) {
+		bodyRender = <Scores 
+		instID={state.instanceID}
+		playID={state.playID}
+		userID={state.userID}
+		token={state.token}
 		isEmbedded={state.isEmbedded}
 		isPreview={state.isPreview}
-	  previewPlayId={previewPlayId}/>
+		isSingle={state.isSingle}/>
 	}
+
+	if (state.isEmbedded) document.body.classList.add('embedded')
 
 	return (
 		<>

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -1,10 +1,11 @@
 import React, { useState, useEffect, useRef} from 'react'
-import { apiGetWidgetInstance, apiGetWidgetInstanceScores, apiGetScoreSummary, apiGetScoreDistribution, apiGetWidgetInstancePlayScores, apiGetWidgetInstancePreviewScores } from '../util/api'
 import { useQuery } from 'react-query'
+import { apiGetWidgetInstance, apiGetWidgetInstanceScores, apiGetWidgetInstancePlayScores, apiGetWidgetInstancePreviewScores } from '../util/api'
+
+import LoadingIcon from './loading-icon'
 import ScoreOverview from './score-overview'
 import ScoreDetails from './score-details'
 import SupportInfo from './support-info'
-import LoadingIcon from './loading-icon'
 
 import './scores.scss'
 
@@ -12,189 +13,100 @@ const STATE_RESTRICTED = 'restricted'
 const STATE_INVALID = 'invalid'
 const STATE_EXPIRED = 'expired'
 
-const Scores = ({ instId, playId: playIdProp, single_id, userId, send_token, isEmbedded, isPreview, previewPlayId }) => {
+const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPreview, isSingle}) => {
 
-	const [playId, setPlayId] = useState(null)
-	const [previewInstId, setPreviewInstId] = useState(null)
-
-
-	// attemptDates is an array of attempts, [0] is the newest
-	const [attemptDates, setAttemptDates] = useState([])
-	const [attempts, setAttempts] = useState([])
-	// current attempt is the index of the attempt (the 1st attempt is attempts.length)
-	const [currentAttempt, setCurrentAttempt] = useState(null)
-	const [attemptsLeft, setAttemptsLeft] = useState(0)
-	const [attemptNum, setAttemptNum] = useState(null)
-
-	const [overview, setOverview] = useState()
-	const [playDetails, setPlayDetails] = useState(null)
-	const [prevAttemptOpen, setprevAttemptOpen] = useState(false)
-
-	// set to one of the state constants above if an error state manifests
+	const [playID, setPlayID] = useState(playIDProp)
 	const [errorState, setErrorState] = useState(null)
+	const [attemptsLeft, setAttemptsLeft] = useState(0)
+	const [currentAttempt, setCurrentAttempt] = useState(null)
 
-	const [showScoresOverview, setShowScoresOverview] = useState(true)
-	const [showResultsTable, setShowResultsTable] = useState(true)
-	const [scoreTable, setScoreTable] = useState(null)
+	const [attempts, setAttempts] = useState([])
 
-	const [guestAccess, setGuestAccess] = useState(null)
-	const [attributes, setAttributes] = useState({
-		hidePlayAgain: true,
-		hidePreviousAttempts: true
+	const [playData, setPlayData] = useState({
+		overview: null,
 	})
 
-	const [playAgainUrl, setPlayAgainUrl] = useState(null)
+	const [attributes, setAttributes] = useState({
+		showScoresOverview: true,
+		showResultsTable: true,
+		hidePlayAgain: true,
+		href: '',
+		hidePreviousAttempts: isPreview || isSingle
+	})
+
+	const [keepPrevOpen, setKeepPrevOpen] = useState(false)
+	const [prevAttemptOpen, setprevAttemptOpen] = useState(false)
 
 	const [customScoreScreen, setCustomScoreScreen] = useState({
 		htmlPath: null,
 		type: null,
-		qset: null,
-		scoreTable: null,
 		show: false,
 		loading: true,
 		ready: false
 	})
 
-	const scoreHeaderRef = useRef(null)
 	const scoreWidgetRef = useRef(null)
 
-	const guestPlayId = playIdProp ? playIdProp : single_id
-
-	// Gets widget instance loads qset
-  // No login required
-	const { isLoading: instanceIsLoading, data: instance } = useQuery({
-		queryKey: ['widget-inst', instId],
-		queryFn: () => apiGetWidgetInstance(instId), // TODO: this call also had a second parameter 'true', which i think would be the 'getDeleted' param? but that doesnt make sense in this case, and it's the only place where an additional 'true' was present on this call
-		enabled: !!instId,
+	/*
+	Grab instance information: required for all score screen types
+	*/
+	const { isLoading: instanceIsLoading, data: instance} = useQuery({
+		queryKey: ['widget-inst', instID],
+		queryFn: () => apiGetWidgetInstance(instID),
+		enabled: !!instID,
 		staleTime: Infinity,
 	})
 
-	// Gets widget instance scores
-	// Because of how we handle the results object, we can't follow-up via useEffect targeting instanceScores
-	// As a result, instanceScores is never read.
-	const { isLoading: scoresAreLoading, data: instanceScores, refetch: loadInstanceScores } = useQuery({
-		queryKey: ['inst-scores', instId, send_token, previewPlayId],
-		// @TODO: we are not currently passing in or using send_token
-		queryFn: () => apiGetWidgetInstanceScores(instId, userId),
-		enabled: false, // enabled is set to false so the query can be manually called with the refetch function
-		staleTime: Infinity,
-		refetchOnWindowFocus: false,
-		retry: false,
-		onSuccess: (result) => {
-			_populateScores(result['scores'])
-			setAttemptsLeft(result['attemptsLeft'])
-		},
-		onError: (err) => {
-			if (err.message == "Invalid Login") {
-				setErrorState(STATE_RESTRICTED)
-			} else {
-				setErrorState(STATE_INVALID)
-			}
-		}
-	})
-
-	// Gets widget instance play scores when playId
-	// or previewInstId are changed
-	const { data: playScores } = useQuery({
-		queryKey: ['play-scores', playId, previewInstId, previewPlayId],
+	/*
+	Grab instance score data for a given user
+		Only requested for score screens displayed at end-of-play flow
+		Also disabled for guest plays, preview plays
+	*/
+	const { isLoading: scoresAreLoading, data: instanceScores, error: instanceScoresError, refetch: loadInstanceScores } = useQuery({
+		queryKey: ['inst-scores', instID],
 		queryFn: () => {
-			if (isPreview) return apiGetWidgetInstancePreviewScores(previewPlayId, previewInstId)
-			else return apiGetWidgetInstancePlayScores(playId)
+			return apiGetWidgetInstanceScores(instID, userID)
 		},
+		enabled: !isPreview && !isSingle && !!userID && !!instID,
 		staleTime: Infinity,
-		enabled: (!!playId || (!!previewInstId && !!previewPlayId)),
 		refetchOnWindowFocus: false,
 		retry: false,
-		onError: (err) => {
-			if (err.message == "Invalid Login") {
-				setErrorState(STATE_RESTRICTED)
-			} else if (isPreview) {
-				setAttributes({...attributes, href: `/preview/${instId}/${instance?.clean_name}?previewId=${previewPlayId}`})
-				setErrorState(STATE_EXPIRED)
-			} else {
-				setErrorState(STATE_INVALID)
-			}
-		}
 	})
 
-	// Gets score distribution
-	const { refetch: loadScoreDistribution } = useQuery({
-		queryKey: ['score-dist', instId],
-		queryFn: () => apiGetScoreDistribution(instId),
-		enabled: false,
-		staleTime: Infinity,
-		retry: false,
-		onSuccess: (data) => {
-			_sendToWidget('scoreDistribution', [data])
+	/*
+	Grab play-specific score data. Bound to the current play (or preview) ID.
+	*/
+	const { data: playScores, error: playScoresError } = useQuery({
+		queryKey: ['play-scores', playID],
+		queryFn: () => {
+			if (isPreview) return apiGetWidgetInstancePreviewScores(playID, instID)
+			else return apiGetWidgetInstancePlayScores(playID)
 		},
-		onError: (err) => {
-			if (err.message == "Invalid Login") {
-				setErrorState(STATE_RESTRICTED)
-			} else {
-				setErrorState(STATE_INVALID)
-			}
-		}
+		staleTime: Infinity,
+		enabled: !!playID && !!instance,
+		refetchOnWindowFocus: false,
+		retry: false
 	})
 
+	/*
+	Setup state information based on instance data:
+		- play again URL
+		- feature visibility toggles
+		- custom score screen (if used)
+	*/
 	useEffect(() => {
-		window.addEventListener('hashchange', listenToHashChange)
+		if (!!instance) {
 
-		return () => {
-			window.removeEventListener('hashchange', listenToHashChange)
-		}
-	}, [currentAttempt])
+			let path = (() => {
+				if (isEmbedded) return instance.embed_url
+				if (isPreview) return instance.preview_url
+				return instance.play_url
+			})()
+			if (token) path = `${path}?token=${token}`
 
-	useEffect(() => {
-		// if customScoreScreen is not loading
-		// meaning it has 1) loaded or 2) does not exist
-		if (!customScoreScreen.loading) {
-			// setup the postmessage listener
-			window.addEventListener('message', _onPostMessage, false)
-
-			_displayWidgetInstance()
-
-			// cleanup this listener
-			return () => {
-				window.removeEventListener('message', _onPostMessage, false);
-			}
-		}
-	}, [
-		customScoreScreen.loading,
-		instance,
-	])
-
-	useEffect(() => {
-		// Fetch score data based on instance access
-		if (instance) {
-			setGuestAccess(instance.guest_access)
-			// Preview? Set certain attributes that wouldn't be assigned otherwise
-			if (isPreview) {
-				setPreviewInstId(instance.id)
-				setPlayId(null)
-				setAttributes({ ...attributes, href: instance.preview_url, hidePlayAgain: false })
-			}
-			// Single play session
-			else if (single_id) {
-				setPlayId(single_id)
-				setPreviewInstId(null)
-			}
-			// Guest play session
-			else if (instance.guest_access) {
-				setAttributes({ ...attributes, href: isEmbedded ? instance.embed_url : instance.play_url, hidePlayAgain: false })
-				setPlayId(guestPlayId)
-			}
-			// User play session
-			else loadInstanceScores()
-		}
-	}, [instance])
-
-	// Initializes the custom score screen
-	useEffect(() => {
-		if (instance && playDetails) {
-			let enginePath
 			const score_screen = instance.widget.score_screen
-			// custom score screen exists?
-			if (score_screen && scoreTable) {
+			let enginePath
+			if (score_screen) {
 				const splitSpot = score_screen.lastIndexOf('.')
 				if (splitSpot != -1) {
 					if (score_screen.substring(0, 4) == 'http') {
@@ -205,229 +117,211 @@ const Scores = ({ instId, playId: playIdProp, single_id, userId, send_token, isE
 						enginePath = window.WIDGET_URL + instance.widget.dir + score_screen
 					}
 				}
-				// first time loading the custom score screen
 				if (customScoreScreen.loading == true) {
 					setCustomScoreScreen({
 						...customScoreScreen,
 						htmlPath: enginePath + '?' + instance.widget.created_at,
-						scoreTable: scoreTable,
 						type: 'html',
 						loading: false,
 						show: true,
 					})
-				// custom score screen loaded previously - scoreTable updated, indicating a different play selected
-				// pass the message along to the score screen
-				} else if (customScoreScreen.ready) _sendWidgetUpdate()
-
-			// no score screen - set loading to false regardless now that we know
-			// doing so kicks off _displayWidgetInstance and initializes the postMessage listener
-			} else if (instance.widget && scoreTable) {
-				setCustomScoreScreen({ ...customScoreScreen, loading: false })
-			}
-
-		}
-	}, [instance, playDetails, scoreTable])
-
-	// _displayAttempts
-	useEffect(() => {
-		if (!!attempts) {
-			if (attempts instanceof Array && attempts.length > 0) {
-				let matchedAttempt = false
-				// Reverse attempts so that the most recent attempt has the highest index
-				attempts.reverse()
-
-				// attemptDates is used to populate the overview data in displayWidgetInstance, it's just assembled here.
-				let dates = [ ...attemptDates ]
-
-				// sort added here so it displays the correct date with the attempt and score
-				attempts.forEach((a, i) => {
-					const d = new Date(a.created_at * 1000)
-
-					// attemptDates is used to populate the overview data in displayWidgetInstance, it's just assembled here.
-					let date = { ...dates[i] }
-					date = d.getMonth() + 1 + '/' + d.getDate() + '/' + d.getFullYear()
-					dates[i] = date
-					setAttemptDates(dates)
-
-					if (playIdProp === a.id) {
-						matchedAttempt = attempts.length // sets to uri attempt to the most resent one
-					}
-				})
-
-				if (isPreview) {
-					setCurrentAttempt(1)
-				} else if (matchedAttempt !== false && attempts.length > 1) {
-					// we only want to do this if there's more than one attempt. Otherwise it's a guest widget
-					// or the score is being viewed by an instructor, so we don't want to get rid of the playid
-					// in the hash
-					window.location.hash = `#attempt-${matchedAttempt}`
-
-				} else if (getAttemptNumberFromHash() === undefined) {
-					window.location.hash = `#attempt-${attempts.length - 1}`
-				} else {
-
-					const hash = getAttemptNumberFromHash()
-					if (currentAttempt != hash) {
-						setCurrentAttempt(hash)
-					}
 				}
 			}
-		}
-	}, [attempts])
 
+			setAttributes({
+				...attributes,
+				href: path,
+				title: instance.name,
+				hidePlayAgain: !!instance.guest_access || isSingle,
+				hidePreviousAttempts: instance.guest_access || attributes.hidePreviousAttempts,
+				showResultsTable: !score_screen
+			})
+		}
+	},[instance])
+
+	/*
+	Setup state information based on instance score data:
+		- List of attempts
+		- Remaining attempts
+	*/
 	useEffect(() => {
-		if (!!currentAttempt) {
-			if (guestAccess) {
-				setPlayId(playIdProp)
+		if (!!instanceScores) {
+			if (instanceScores.length < 1) {
+				setErrorState(STATE_INVALID)
 			} else {
+				const scores = Array.from(instanceScores.scores)
+				// Sort scores by created_at in ascending order (oldest first)
+				scores.sort((a, b) => {
+					return a.created_at - b.created_at
+				})
+				for (let score of scores) {
+					score.roundedPercent = parseFloat(score.percent).toFixed(2)
+					const d = new Date(score.created_at * 1000)
+					const date = d.getMonth() + 1 + '/' + d.getDate() + '/' + d.getFullYear()
+					score.date = date
+				}
+				setAttempts(scores)
+				setAttemptsLeft(scores.attemptsLeft)
 				const hash = getAttemptNumberFromHash()
-				setPlayId(attempts[hash - 1].id)
+				if (hash && scores.length >= hash) {
+					setCurrentAttempt(parseInt(hash))
+				}
+
+				if (!attributes.hidePreviousAttempts && scores.length < 2) {
+					setAttributes({...attributes, hidePreviousAttempts: true})
+				}
+			}
+		} else if (!!instanceScoresError) {
+			if (instanceScoresError.message == "Permission Denied") {
+				setErrorState(STATE_RESTRICTED)
+			} else {
+				setErrorState(STATE_INVALID)
 			}
 		}
-	}, [currentAttempt])
+		// @TODO handle errors
+	},[instanceScores, instanceScoresError])
 
+	/*
+	Setup state information based on play data
+		- Score overview
+		- Score table (which is passed to score screen)
+	*/
 	useEffect(() => {
 
-		if (playScores != null) {
-			const deets = playScores
-			setPlayDetails({qset: { ...deets.qset }, details: [ ...deets.details ]})
+		if (!!playScores && !playScoresError) {
 
-			let score
+			let overview = {
+				...playScores.overview,
+				score: Math.round(playScores.overview.score),
+				table: Array.from(playScores.overview.table)
+			}
 
-			// Round the score for display
-			for (tableItem of Array.from(deets.details[0].table)) {
-				score = parseFloat(tableItem.score)
-				if (score !== 0 && score !== 100) {
+			let details = {
+				...playScores.details[0],
+				table: Array.from(playScores.details[0].table)
+			}
+			
+			for (let tableItem of details.table) {
+				let score = parseFloat(tableItem.score)
+				if (score != 0 && score != 100) {
 					tableItem.score = score.toFixed(2)
 				}
 			}
 
-			// send the materiaScoreRecorded postMessage
-			// previously within the if block below, but should happen regardless of whether the overview is shown
-			deets.overview.score = Math.round(deets.overview.score)
-			sendPostMessage(deets.overview.score)
-
-			if (showScoresOverview) {
-				for (var tableItem of Array.from(deets.overview.table)) {
+			sendPostMessage(overview.score)
+			if (attributes.showScoresOverview) {
+				for (let tableItem of overview.table) {
+					// convert each table value to a float if it's a string
 					if (tableItem.value.constructor === String) {
 						tableItem.value = parseFloat(tableItem.value)
 					}
+					// set to a fixed decimal length of 2
 					tableItem.value = tableItem.value.toFixed(2)
 				}
-
-				setOverview(deets.overview)
-				setAttemptNum(currentAttempt)
 			}
-
-			const referrerUrl = deets.overview.referrer_url
-			if (deets.overview.auth === 'lti' && !!referrerUrl && referrerUrl.indexOf(`/scores/${instId}`) === -1) {
-				setPlayAgainUrl(referrerUrl)
-			} else if (!single_id) {
-				setPlayAgainUrl(attributes.href)
-			}
-
-			setScoreTable(deets.details[0].table)
+			setPlayData((playData) => ({
+				id: playID,
+				overview: overview,
+				qset: { ...playScores.qset },
+				details: details
+			}))
 		}
-	}, [playScores])
+		else if (!!playScoresError) {
+			if (playScoresError.message == "Permission Denied") setErrorState(STATE_RESTRICTED)
+			else if (isPreview) setErrorState(STATE_EXPIRED)
+			else setErrorState(STATE_INVALID)
+		}
+		// @TODO handle errors
+	}, [playScores, playScoresError])
 
+	/*
+	When parsed play data is updated, send it to the custom score screen (if enabled)
+	*/
 	useEffect(() => {
-		if (instance && !single_id) {
-			// show play again button?
-			if (instance.attempts <= 0 || parseInt(attemptsLeft) > 0 || isPreview) {
-				let path = (() => {
-					// @TODO: previews will never trigger this hook, is the isPreview check needed?
-					if (isEmbedded) return instance.embed_url
-					if (isPreview) return instance.preview_url
-					return instance.play_url
-				})()
+		if (!errorState && customScoreScreen.show) {
+			sendToWidget('updateWidget', [playData.qset, playData.details.table])
+		}
+	},[playData.id])
 
-				// attach token to play again path if present
-				const urlParams = new URLSearchParams(window.location.search)
-				const token = urlParams.get('token')
-				if (token) {
-					path = `${path}?token=${token}`
-				}
+	/*
+	Setup postMessage listeners for communication between this frame and score screen
+	*/
+	useEffect(() => {
+		if (!!playData.id) {
+			if (!customScoreScreen.loading) {
+				window.addEventListener('message', onPostMessage, false)
+			}
+			return () => {
+				window.removeEventListener('message', onPostMessage, false)
+			}
+		}
+	},[customScoreScreen.loading, playData.id])
 
+	/*
+	Setup hash change listener
+	*/
+	useEffect(() => {
+		window.addEventListener('hashchange', listenToHashChange)
+
+		return () => {
+			window.removeEventListener('hashchange', listenToHashChange)
+		}
+	}, [currentAttempt])
+
+	/*
+	Update tracked playID when attempt hash changes
+	*/
+	useEffect(() => {
+		if (!!currentAttempt) {
+			if (instance?.guest_access || isSingle || isPreview) return false
+			else {
+				const hash = getAttemptNumberFromHash()
+				setPlayID(attempts[hash - 1].id)
+			}
+		}
+	},[currentAttempt])
+
+	/*
+	send postMessage to the score screen frame
+	*/
+	const sendToWidget = (type, args) => {
+		return scoreWidgetRef.current.contentWindow.postMessage(
+			JSON.stringify({ type, data: args }),
+			window.STATIC_CROSSDOMAIN
+		)
+	}
+
+	/*
+	Score screen initialization and error handling
+	*/
+	const sendWidgetInit = () => {
+		if (!errorState) { 
+			if (customScoreScreen.loading || (customScoreScreen.show && scoreWidgetRef.current == null)) {
+				setCustomScoreScreen({
+					...customScoreScreen,
+					show: false
+				})
 				setAttributes({
 					...attributes,
-					href: path,
-					hidePlayAgain: false
-				})
-			} else {
-				// if there are no attempts left, hide play again
-				setAttributes({
-					...attributes,
-					hidePlayAgain: true
+					showScoresOverview: true,
+					showResultsTable: true
 				})
 			}
-		}
-	}, [attemptsLeft])
-
-	const listenToHashChange = () => {
-		const hash = getAttemptNumberFromHash()
-		if (currentAttempt != hash) setCurrentAttempt(hash)
-	}
-
-	const _populateScores = (scores) => {
-		if (!scores || scores.length < 1) {
-			// score request was not in error, but request is empty
-			setErrorState(STATE_INVALID)
-
-		} else {
-			// Round scores
-			for (let attemptScore of Array.from(scores)) {
-				attemptScore.roundedPercent = String(parseFloat(attemptScore.percent).toFixed(2))
-			}
-
-			setAttempts(scores)
-			const hash = getAttemptNumberFromHash()
-			if (hash && scores.length >= hash) {
-			  setCurrentAttempt(parseInt(hash))           // This triggers the correct useEffect
-			  setPlayId(scores[hash - 1].id)              // Ensures we fetch the play details
-			}
-
-
+			console.log("calling sendToWidget")
+			sendToWidget('initWidget', [playData.qset, playData.details.table, instance, isPreview, window.MEDIA_URL])
 		}
 	}
 
-	// only referenced once, after instance is loaded
-	const _displayWidgetInstance = () => {
-		// Build the data for the overview section
-		let overview = {
-			title: instance.name,
-			dates: attemptDates,
-		}
-
-		// Modify display of several elements after HTML is outputted
-		const lengthRange = Math.floor(instance.name.length / 10)
-		let textSize = 24
-		let paddingSize = 16
-
-		switch (lengthRange) {
-			case 0:
-			case 1:
-			case 2:
-				textSize -= 4
-				paddingSize += 4
-				break
-			case 3:
-				textSize -= 8
-				paddingSize += 8
-				break
-			default:
-				textSize -= 12
-				paddingSize += 12
-		}
-
-		overview.headerStyle = {
-			'fontSize': textSize,
-			'paddingTop': paddingSize,
-		}
-
-		setAttributes({...attributes, ...overview, hidePreviousAttempts: !!single_id || attempts.length < 2 })
+	const setHeight = (h) => {
+		const min_h = instance.widget.height
+		let desiredHeight = Math.max(h, min_h)
+		scoreWidgetRef.current.style.height = `${desiredHeight}px`
 	}
 
-	const _onPostMessage = (e) => {
+	/*
+	Handler for incoming postMessages from the custom score screen frame
+	*/
+	const onPostMessage = (e) => {
 		const origin = `${e.origin}/`
 		if (origin === window.STATIC_CROSSDOMAIN || origin === window.BASE_URL) {
 			const msg = JSON.parse(e.data)
@@ -435,15 +329,20 @@ const Scores = ({ instId, playId: playIdProp, single_id, userId, send_token, isE
 				case 'score-core':
 					switch (msg.type) {
 						case 'start':
-							return _sendWidgetInit()
+							return sendWidgetInit()
 						case 'setHeight':
-							return _setHeight(msg.data[0])
+							return setHeight(msg.data[0])
 						case 'hideResultsTable':
-							return (setShowResultsTable(false))
+							return setAttributes({...attributes, showResultsTable: false})
 						case 'hideScoresOverview':
-							return (overview?.complete ? setShowScoresOverview(false) : setShowScoresOverview(true))
+							return (playData?.overview?.complete ? 
+								setAttributes({...attributes, showScoresOverview: false}) :
+								setAttributes({...attributes, showScoresOverview: true})
+							)
 						case 'requestScoreDistribution':
-							return loadScoreDistribution()
+							// @TODO
+							// return loadScoreDistribution()
+							return false
 						default:
 							console.warn(`Unknown PostMessage received from score core: ${msg.type}`)
 							return false
@@ -483,7 +382,10 @@ const Scores = ({ instId, playId: playIdProp, single_id, userId, send_token, isE
 		}
 	}
 
-	/****** helper methods ******/
+	const listenToHashChange = () => {
+		const hash = getAttemptNumberFromHash()
+		if (currentAttempt != hash) setCurrentAttempt(hash)
+	}
 
 	const getAttemptNumberFromHash = () => {
 		const match = window.location.hash.match(/^#attempt-(\d+)/)
@@ -494,49 +396,6 @@ const Scores = ({ instId, playId: playIdProp, single_id, userId, send_token, isE
 		return attempts.length
 	}
 
-	const _sendToWidget = (type, args) => {
-		return scoreWidgetRef.current.contentWindow.postMessage(
-			JSON.stringify({ type, data: args }),
-			window.STATIC_CROSSDOMAIN
-		)
-	}
-
-	// this is only called in response from the score-core
-	// it will not be called for default score screens
-	const _sendWidgetInit = () => {
-		if (customScoreScreen.scoreTable == null || playDetails == null || scoreWidgetRef.current == null) {
-			// Custom score screen failed to load, load default overview instead
-			setCustomScoreScreen({ ...customScoreScreen, loading: true, show: false })
-			setShowResultsTable(true)
-			setShowScoresOverview(true)
-			return
-		}
-		setCustomScoreScreen({ ...customScoreScreen, ready: true })
-
-		_sendToWidget('initWidget', [playDetails.qset, customScoreScreen.scoreTable, instance, isPreview, window.MEDIA_URL])
-	}
-
-	// tell the custom score screen that the selected attempt/play has changed, and pass the new scoreTable accordingly
-	const _sendWidgetUpdate = () => {
-		_sendToWidget('updateWidget', [playDetails.qset, scoreTable])
-	}
-
-	const _setHeight = (h) => {
-		const min_h = instance.widget.height
-		let desiredHeight = Math.max(h, min_h)
-		scoreWidgetRef.current.style.height = `${desiredHeight}px`
-	}
-
-	const attemptClick = () => {
-		// @TODO isMobile relies on include.js which is no longer bundled
-		// if (window.isMobile.any()) {
-		// 	setprevAttemptOpen(false)
-		// }
-	}
-
-	/******* DOM element rendering ********/
-
-	// Render error states, if any are active
 	let errorStateRender = null
 	if (errorState != null) {
 		switch (errorState) {
@@ -545,7 +404,7 @@ const Scores = ({ instId, playId: playIdProp, single_id, userId, send_token, isE
 					<div className="expired container general">
 						<section className="page score_expired">
 							<h2 className="logo">The preview score for this widget has expired.</h2>
-							<p>Preview scores are only available immediately after previewing a widget.</p>
+							<p>Preview scores are only available for a limited time after previewing a widget.</p>
 							<a className="action_button" href={attributes.href ? attributes.href : '#'}>Preview Again</a>
 						</section>
 					</div>
@@ -586,32 +445,28 @@ const Scores = ({ instId, playId: playIdProp, single_id, userId, send_token, isE
 		}
 	}
 
-	let previousAttempts = null
-	if (!attributes.hidePreviousAttempts && !isPreview && !guestAccess) {
-
+	let priorAttempts = null
+	if (!attributes.hidePreviousAttempts) {
 		let attemptList = attempts.map((attempt, index) => {
 			return (
 				<li key={index}>
-					<a
-						href={`#attempt-${index + 1}`}
-						onClick={attemptClick}
+					<a href={`#attempt-${index + 1}`}
+						onClick={() => setKeepPrevOpen(false)}
 					>
-						Attempt {index + 1}:
+						<span>Attempt {index + 1}: <span className="date">{attempt.date}</span></span>
 						<span className="score">{attempt.roundedPercent}%</span>
-						<span className="date">{attemptDates[index]}</span>
 					</a>
 				</li>
 			)
 		}).reverse()
-		// Reverses attempt list so that the most recent appears at top
-
-		previousAttempts = (
+		
+		priorAttempts = (
 			<nav
-				className={`header-element previous-attempts ${prevAttemptOpen ? 'open' : ''}`}
+				className={`previous-attempts ${prevAttemptOpen || keepPrevOpen ? 'open' : ''}`}
 				onMouseOver={() =>!prevAttemptOpen && setprevAttemptOpen(true)}
 				onMouseLeave={() => prevAttemptOpen && setprevAttemptOpen(false)}
 			>
-				<h1 onClick={() => !prevAttemptOpen && setprevAttemptOpen(true)}>
+				<h1 onClick={() => setKeepPrevOpen(!keepPrevOpen)}>
 					Prev. Attempts
 				</h1>
 				<ul>
@@ -624,75 +479,61 @@ const Scores = ({ instId, playId: playIdProp, single_id, userId, send_token, isE
 	let playAgainBtn = null
 	if (!attributes.hidePlayAgain) {
 		playAgainBtn = (
-			<nav className="play-again header-element">
-				<h1>
-					<a id="play-again" className="action_button" href={playAgainUrl}>
-						{isPreview ? 'Preview' : 'Play'} Again
-						{attemptsLeft > 0 ? <span>({attemptsLeft} Left)</span> : <></>}
-					</a>
-				</h1>
-			</nav>
+			<a id='play-again' className='action_button' href={attributes.href}>
+				{isPreview ? 'Preview' : 'Play'} Again
+				{attemptsLeft > 0 ? <span>({attemptsLeft} Left)</span> : <></>}
+			</a>
 		)
 	}
 
-	let scoreHeader = null
+	let scoreHeaderRender = null
 	if (!errorState) {
-		scoreHeader = (
+		scoreHeaderRender = (
 			<header className={`header score-header ${isPreview ? 'preview' : ''}`}>
-				{previousAttempts}
-				<h1 className="header-element widget-title" ref={scoreHeaderRef} style={attributes.headerStyle ? attributes.headerStyle : {}}>{attributes.title ? attributes.title : ''}</h1>
+				{priorAttempts}
+				<h1 className='widget-title'>{attributes.title ? attributes.title : ''}</h1>
 				{playAgainBtn}
 			</header>
 		)
 	}
 
 	let overviewRender = null
-	if (!errorState && showScoresOverview && !!overview) {
-		if (customScoreScreen.show && !customScoreScreen.ready) {
-			overviewRender = (
-				<section className={`overview ${isPreview ? 'preview' : ''}`}>
-					<div className='loading-icon-holder'><LoadingIcon size='med' /></div>
-				</section>
-			)
-		}
-		else {
-			overviewRender = <ScoreOverview
-				inst_id={instId}
-				single_id={single_id}
-				overview={overview}
-				attemptNum={attemptNum}
-				isPreview={isPreview}
-				guestAccess={guestAccess} />
-		}
-
+	if (!errorState && attributes.showScoresOverview && !!playData.overview) {
+		overviewRender = <ScoreOverview
+			inst_id={instID}
+			single_id={null}
+			overview={playData.overview}
+			attemptNum={currentAttempt}
+			isPreview={isPreview}
+			guestAccess={instance?.guest_access} />
 	}
 
 	let customScoreScreenRender = null
-	//if (!errorState && customScoreScreen.show) {
+	if (!errorState && customScoreScreen.show) {
 		customScoreScreenRender = (
 			<iframe ref={scoreWidgetRef}
-				id="container"
-				className={`html ${showScoresOverview ? 'margin-above' : ''}${showResultsTable ? 'margin-below' : ''}${!overview?.complete ? ' incomplete' : ''}`}
+				id='container'
+				className={`html ${!playData.overview?.complete ? 'incomplete' : ''}`}
 				src={customScoreScreen.htmlPath}>
 			</iframe>
 		)
-	//}
+	}
 
 	let detailsRender = null
-	if (!errorStateRender && customScoreScreen.show && !customScoreScreen.ready) {
+	if (!errorState && !playData.id) {
 		detailsRender = (
 			<section className={`overview ${isPreview ? 'preview' : ''}`}>
 				<div className='loading-icon-holder'><LoadingIcon size='med' /></div>
 			</section>
 		)
-	} else if (!errorStateRender && showResultsTable) {
-		detailsRender = <ScoreDetails details={playDetails?.details} complete={overview?.complete} />
+	} else if (!errorState && attributes.showResultsTable) {
+		detailsRender = <ScoreDetails details={playData?.details} complete={playData.overview?.complete} />
 	}
 
 	return (
-		<article className={`container ${ instanceIsLoading || scoresAreLoading ? 'loading' : 'ready'}`}>
+		<article className={`container ${instanceIsLoading || scoresAreLoading ? 'loading' : 'ready'}`}>
 			<div className='loading-icon-holder'><LoadingIcon size='med' /></div>
-			{scoreHeader}
+			{scoreHeaderRender}
 			{overviewRender}
 			{customScoreScreenRender}
 			{detailsRender}

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -423,9 +423,13 @@ article {
 
 						font-size: 0.8em;
 
+						border-bottom: solid 2px rgba(0,0,0,0);
+
 						&:hover {
-							padding: 0 0 0.25em 0;
+							padding: 0;
 							text-decoration: none;
+
+							border-bottom: 2px solid #0093E7;
 						}
 
 						.date {
@@ -793,5 +797,11 @@ iframe#container {
 
 	&.incomplete {
 		filter: blur(2px);
+	}
+}
+
+@media (max-width: 720px) {
+	.score-header nav {
+		max-height: none;
 	}
 }

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -49,14 +49,22 @@ $preview-purple: #b944cc;
 
 	&.expired, &.invalid, &.score_restrict {
 		min-height: 480px;
-		padding: 20px 40px;
 		background: #fff;
 
 		.page {
+			font-size: 1em;
+			font-weight: 400;
 			text-align: center;
 
+			h2 {
+				margin-bottom: 1em;
+				padding: 1em 0;
+				color: #fff;
+				background: $color-features;
+			}
+
 			p {
-				margin-bottom: 40px;
+				margin: 0 0 1em 0;
 			}
 
 			ul {
@@ -67,6 +75,10 @@ $preview-purple: #b944cc;
 				li {
 					margin-bottom: 5px;
 				}
+			}
+
+			.error-support {
+				padding-bottom: 1em;
 			}
 		}
 	}
@@ -275,11 +287,13 @@ article {
 	header {
 		z-index: 8;
 		position: relative;
-		padding: 0px 0px 15px;
-		height: auto;
-		min-height: 50px;
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		min-height: 65px;
 
 		margin: 0;
+		padding: 0 1em;
 
 		background: $header-color;
 		border-top-left-radius: 5px;
@@ -322,17 +336,15 @@ article {
 			}
 		}
 
-		.header-element {
-			display: inline-block;
-		}
-
-		.header-element.widget-title {
-			max-width: 500px;
-			padding-bottom: 5px;
-			padding-top: 16px;
+		h1.widget-title {
 			overflow-wrap: break-word;
-			word-wrap: break-word; // have to include word-wrap since Edge/IE11 will not support overflow-wrap
-			margin-left: -10px;
+			word-wrap: break-word;
+			font-size: clamp(16px, 2vw, 21px);
+			color: #fff;
+
+			&:only-child {
+				margin: 0 auto;
+			}
 		}
 
 		nav {
@@ -341,37 +353,24 @@ article {
 			opacity: 1;
 		}
 
-		nav.play-again {
-			margin: 12px;
-			padding: 0;
-			position: absolute;
-			top: 0px;
-			right: 0px;
-
-			h1 {
-				margin: 0;
-				padding: 0;
-
-				#play-again span {
-					margin-left: 0.5em;
-					font-size: 12px;
-				}
+		button#play-again {
+			#play-again span {
+				margin-left: 0.5em;
+				font-size: 12px;
 			}
 		}
 
 		nav.previous-attempts {
-			cursor: default;
-			position: absolute;
-			top: 0px;
-			left: 0px;
+			position: relative;
+			cursor: pointer;
 			margin: 0px;
 			text-align: left;
 			user-select: none;
 
 			h1 {
 				display: inline-block;
+				margin: 0;
 				padding: 10px 18px;
-				margin: 14px 0 0 10px;
 
 				font-size: 12px;
 				color: #000;
@@ -386,60 +385,67 @@ article {
 				h1 {
 					color: #222;
 					background: #d0eeff;
+					border-bottom-left-radius: 0;
+					border-bottom-right-radius: 0;
 				}
 
 				ul {
-					display: block !important;
-					margin-top: 10px;
+					display: block;
 				}
 			}
 
 			ul {
-				display: none;
-				background: #fff;
-				margin: 0;
 				z-index: 10;
-				position: relative;
-				margin-left: 6px;
+				position: absolute;
+				display: none;
+				min-width: 175px;
+				margin: 0;
 				border-radius: 15px;
+				border-top-left-radius: 0;
+				background: #fff;
 				box-shadow: 5px 5px 15px 1px #666;
 
-				.date {
-					margin-top: 5px;
-					color: #005391;
-					font-size: 12px;
-					display: block;
-					font-weight: normal;
-				}
-
-				.score {
-					color: #333;
-					font-weight: bold;
-					font-size: 20px;
-					padding-left: 10px;
-				}
-
 				li {
-					padding: 5px 15px;
-					list-style: none;
 					display: block;
+					padding: 0.5em 1em;
+					list-style: none;
+
+					border-radius: 15px;
 
 					&:hover {
 						background-color: #d0eeff;
-						border-radius: 15px;
 					}
 
-					a:hover {
-						text-decoration: none;
+					a {
+						display: flex;
+						flex-direction: column;
+						gap: 0.25em;
+
+						font-size: 0.8em;
+
+						&:hover {
+							padding: 0 0 0.25em 0;
+							text-decoration: none;
+						}
+
+						.date {
+							color: #005391;
+							margin-left: 0.5em;
+
+							font-size: 0.9em;
+							font-weight: bold;
+						}
+		
+						.score {
+							color: #333;
+							font-weight: bold;
+							font-size: 1.5em;
+						}
 					}
+
+
 				}
 			}
-		}
-
-		> h1 {
-			color: #fff;
-			margin: 0px;
-			padding-top: 8px;
 		}
 	}
 

--- a/src/components/widget-player.jsx
+++ b/src/components/widget-player.jsx
@@ -529,7 +529,7 @@ const WidgetPlayer = ({instanceId, playId, minHeight=0, minWidth=0,showFooter=tr
 	const _initScoreScreenUrl = () => {
 		let _scoreScreenURL = ''
 			if (isPreview) {
-				_scoreScreenURL = `${window.BASE_URL}scores/preview/${instanceId}?previewId=${previewPlayId}`
+				_scoreScreenURL = `${window.BASE_URL}scores/preview/${instanceId}/${previewPlayId}`
 			} else if (isEmbedded) {
 				_scoreScreenURL = `${window.BASE_URL}scores/embed/${instanceId}/${playId}`
 			} else {

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -93,6 +93,7 @@ export const apiGetWidgetInstances = (user, pageParam) => {
 	return handleRequest(methods.GET, `/api/instances/?user=${user}&page=${pageParam}`)
 }
 
+// @TODO support getDeleted?
 export const apiGetWidgetInstance = (instId, getDeleted=false) => {
 	return handleRequest(methods.GET, `/api/instances/${instId}/`)
 }
@@ -263,6 +264,7 @@ export const apiSearchInstances = (input, pageParam = 1, include_deleted = false
 
 // TODO update or retire
 export const apiGetWidgetInstanceScores = (instId, userId) => {
+	console.log(`inst id: ${instId}, user id: ${userId}`)
 	return handleRequest(methods.GET, `/api/scores/?inst_id=${instId}&user=${userId}`)
 }
 
@@ -280,7 +282,7 @@ export const apiGetScoreDistribution = instId => {
 }
 
 export const apiGetScoreSummary = instId => {
-	return handleRequest(methods.GET, `/api/instances/${instId}/scores/`)
+	return handleRequest(methods.GET, `/api/instances/${instId}/performance/`)
 	.then(data => {
 		const scores = data
 		const ranges = [


### PR DESCRIPTION
- Improvements and fixes for `play-sessions` API perms.
- Condensed play session serializers into a single serializer.
- Preview score screen URLs normalized to the standard score screen URL format.
- Complete rebuild of score screen components to address cruft.
