### PR TITLE
adds focus property to show focus-indicator to buttons

### DIFF
--- a/src/components/widget-creator-page.scss
+++ b/src/components/widget-creator-page.scss
@@ -301,6 +301,10 @@ a {
 	cursor: pointer;
 }
 
+.edit_button:focus {
+	outline: 4px solid  #0078ff;
+}
+
 .green {
 	background:rgb(196, 221, 97);
 	color: rgb(82, 82, 82);


### PR DESCRIPTION
This PR  addresses issue #84  and simply adds a css property to the `edit_button` class which applys to all 3 buttons. 

It ends up looking like this when you tab to either of the 3 buttons. 
<img width="670" height="70" alt="image" src="https://github.com/user-attachments/assets/e24bab93-7be6-48ad-a4a2-84eb1cc66bd0" />
