### PR TITLE
makes react not rerender after intial page load, adds overflow anchor…

### DIFF
--- a/src/components/profile-page.jsx
+++ b/src/components/profile-page.jsx
@@ -39,9 +39,9 @@ const ProfilePage = () => {
 	})
 
 	useEffect(() => {
+		if (!userActivity?.plays) return
 		if (userActivity?.plays) {
 			const newActivity = userActivity.plays.map((log) => {
-				// return {
 				const activity = {
 					is_complete: log.is_complete,
 					inst_id: log.instance,
@@ -55,9 +55,10 @@ const ProfilePage = () => {
 				}
 					return activity
 			})
-			setActivityData(data => [...newActivity])
+			//dont replace the array but append so it dosent have to re-render
+			setActivityData( prev => [...prev, ...newActivity])
 		}
-	},[userActivity?.plays.length])
+	},[userActivity?.plays])
 
 	useEffect(() => {
 		mounted.current = true
@@ -88,7 +89,6 @@ const ProfilePage = () => {
 
 	let noActivityRender = <p className='no_logs'>You don't have any activity! Once you play a widget, your score history will appear here.</p>
 
-	// let activityContentRender = <></>
 	let activityContentRender = activityData.map((record) => {
 			return <li className={`activity_log ${record.is_complete == 1 ? 'complete' : 'incomplete'} ${record.score == 100 ? 'perfect_score' : ''}`} key={record.play_id}>
 				<a className='score-link' href={record.link}>
@@ -115,9 +115,17 @@ const ProfilePage = () => {
 		)
 	}
 
-	let mainContentRender = <section className='page'><div className='loading-icon-holder'><LoadingIcon /></div></section>
-	if ( !isFetching && !userActivity?.isFetching && currentUser) {
+
+	const isInitialLoad = (isFetching || userActivity?.isFetching) && activityData.length == 0
+	const isFetchingNextRequest = userActivity?.isFetching && activityData.length > 0
+
+	let mainContentRender
+	if(isInitialLoad || !currentUser) {
+		mainContentRender = <section className='page'><div className='loading-icon-holder'><LoadingIcon /></div></section>
+	}
+	else {
 		mainContentRender =
+			<>
 			<section className="page user">
 
 				<ul className="main_navigation">
@@ -147,15 +155,21 @@ const ProfilePage = () => {
 				<span className="activity_subheader">Activity</span>
 
 				<div className='activity'>
-					<div className={`loading-icon-holder ${userActivity?.isFetching ? 'loading' : ''}`}><LoadingIcon /></div>
+					{isFetchingNextRequest && ( <div className='loading-icon-holder'> <LoadingIcon /> </div> )}
 					<ul className='activity_list'>
 						{activityData.length ? activityContentRender : noActivityRender}
 					</ul>
 				</div>
 
-				{ userActivity?.hasNextPage ? <a className="show_more_activity action_button" onClick={_getMoreLogs}>{ userActivity.isFetching ? <span className='message_loading'>Loading...</span> : <span>Show more</span>}</a> : '' }
+				{ userActivity?.hasNextPage ?
+					<a className="show_more_activity action_button" onClick={_getMoreLogs}>{ userActivity.isFetching ?
+						<span className='message_loading '>Loading...</span> :
+						<span >Show more</span>}</a> : ''
+				}
 
 			</section>
+			<div className="bottom_anchor"> &nbsp;</div>
+			</>
 	}
 
 	return (

--- a/src/components/profile-page.jsx
+++ b/src/components/profile-page.jsx
@@ -19,6 +19,7 @@ const ProfilePage = () => {
 	let userActivity =  useGetPlaySessions("me", false)
 
 	const mounted = useRef(false)
+	const bottomRef = useRef(false)
 	const { data: currentUser, isFetching} = useQuery({
 		queryKey: ['user', 'me'],
 		queryFn: ({ queryKey }) => {
@@ -59,6 +60,13 @@ const ProfilePage = () => {
 			setActivityData( prev => [...prev, ...newActivity])
 		}
 	},[userActivity?.plays])
+
+	useEffect( () => {
+		console.log("Scrolling")
+		requestAnimationFrame(() => {
+			bottomRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' })
+		})
+	}, [activityData])
 
 	useEffect(() => {
 		mounted.current = true
@@ -168,7 +176,7 @@ const ProfilePage = () => {
 				}
 
 			</section>
-			<div className="bottom_anchor"> &nbsp;</div>
+			<div id="bottom_anchor" ref={bottomRef}> &nbsp;</div>
 			</>
 	}
 

--- a/src/components/profile-page.scss
+++ b/src/components/profile-page.scss
@@ -27,15 +27,6 @@
 		border-radius: 4px;
 		border: #e4e4e4 1px solid;
 		box-shadow: 1px 3px 10px #dcdcdc;
-		overflow-anchor: none;
-
-		.bottom_anchor {
-			overflow-anchor: auto;
-			display: flex;
-			justify-content: center;
-			min-height:2px;
-			background-color: inherit;
-		}
 	}
 
 	section.page {
@@ -43,7 +34,7 @@
 		top: 0;
 		right: 0;
 		z-index: 100;
-		width: 575px; /*625px*/
+		width: 575px;
 		padding: 10px 60px 30px 145px;
 		background: url('/static/img/user_page_background.gif') 0 0 repeat-y;
 		background-color: #fff;

--- a/src/components/profile-page.scss
+++ b/src/components/profile-page.scss
@@ -27,6 +27,15 @@
 		border-radius: 4px;
 		border: #e4e4e4 1px solid;
 		box-shadow: 1px 3px 10px #dcdcdc;
+		overflow-anchor: none;
+
+		.bottom_anchor {
+			overflow-anchor: auto;
+			display: flex;
+			justify-content: center;
+			min-height:2px;
+			background-color: inherit;
+		}
 	}
 
 	section.page {


### PR DESCRIPTION
This PR addresses #83 by minimally rewriting how react renders the page while also having the page be anchored to the bottom with css when the user clicks the `Show more` button. 

The first part fixed an issue with the content in the page being destroyed briefly(and then rebuilt) every time there was a network request. This happened cause the page was being rendered based on  the `if ( !isFetching && !userActivity?.isFetching && currentUser) {`  condition which would be false whenever we clicked the show more button. Because of this, there would be a slight flicker of the spinning icon where the page would shrink and then get re-rendered with the new 6 items. There was also an issue with the `setActivityData` replacing the entire array instead of appending the new 6 items which would also contribute to the janky scroll feeling and the part of the page being destroyed and rebuilt.

In the new fix, we only show the spinner icon when we first load the page, and whenever new content is request we do not replace the entire the array but only add to the existing array. The way it sticks to the bottom when clicking `Show more` is having an element within view that contains a css property of `anchor-overflow: auto` while also making sure the other elements have no `anchor-overflow`. This method should work on every browser except for those on a specific version of Safari on IOS. That being said, using this method we are not able to smoothly animate the scrolling into view unless we do it with JavaScript(which would be supported on every browser). 

I personally think the css trick is pretty neat however but let me know if having it done with JavaScript with like a `element.scrollIntoView({ behavior: "smooth",})` would be preferred. It wouldn't look as jank as how it does on QA since if it doesn't have scroll all the way to the top and then to the bottom(because it isn't destroyed and then rebuilt now). 