### PR TITLE
Django Admin Button

### DIFF
--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -65,7 +65,7 @@ const Header = ({
 						<a className='elevated' href='/admin/instance'>Instances</a>
 					</li>
 					<li>
-						<a className='elevated' href='/admin/'>Django Admin</a>
+						<a className='elevated' href='/admin/' target="_blank">Django Admin</a>
 					</li>
 				</ul>
 			</li>

--- a/src/components/header.jsx
+++ b/src/components/header.jsx
@@ -30,7 +30,7 @@ const Header = ({
 
 	useEffect(() => {
 		if (userPerms != undefined) {
-			
+
 			setVerified(!!userPerms.isAuthenticated)
 			setPermLevel(userPerms.permLevel ?? 'anonymous')
 		}
@@ -63,6 +63,9 @@ const Header = ({
 					</li>
 					<li>
 						<a className='elevated' href='/admin/instance'>Instances</a>
+					</li>
+					<li>
+						<a className='elevated' href='/admin/'>Django Admin</a>
 					</li>
 				</ul>
 			</li>

--- a/src/components/include.scss
+++ b/src/components/include.scss
@@ -351,22 +351,23 @@ header {
 
 	.nav_expandable {
 		color: #0093e7;
-		font-size: 17px;
 		font-weight: bold;
-		height: 27px;
 		position: relative;
-		margin-left: 20px;
+		margin-left: 10px;
 
 		ul {
 			display: none;
 			background-color: #ffffff;
-			padding: 0;
+			padding: 5px 15px;
+			height: 30px;
 			position: absolute;
-			bottom: -140%;
-			left: -10px;
-			border-left: 1px solid #d3d3d3;
-			border-right: 1px solid #d3d3d3;
-			border-bottom: 1px solid #d3d3d3;
+			top: 100%;
+			left: 0;
+			border: 1px solid #d3d3d3;
+			border-radius: 5px;
+			margin-top: 5px;
+			gap: 30px;
+			box-shadow: 0 0 5px rgba(0,0,0,0.1);
 		}
 
 		&:hover > span {
@@ -384,10 +385,14 @@ header {
 
 		&:hover > ul {
 			display: flex;
-
 			li {
-				padding: 0 10px 5px;
-				height: auto;
+				display: flex;
+				padding: 0;
+				align-items: center;
+
+				a {
+					text-wrap: nowrap;
+				}
 			}
 		}
 	}

--- a/src/components/include.scss
+++ b/src/components/include.scss
@@ -358,15 +358,14 @@ header {
 		ul {
 			display: none;
 			background-color: #ffffff;
-			padding: 5px 15px;
-			height: 30px;
+			padding: 15px 15px;
 			position: absolute;
 			top: 100%;
 			left: 0;
 			border: 1px solid #d3d3d3;
 			border-radius: 5px;
 			margin-top: 5px;
-			gap: 30px;
+			gap: 15px;
 			box-shadow: 0 0 5px rgba(0,0,0,0.1);
 		}
 
@@ -385,10 +384,13 @@ header {
 
 		&:hover > ul {
 			display: flex;
+			flex-direction: column;
+
 			li {
 				display: flex;
 				padding: 0;
 				align-items: center;
+				height: 20px;
 
 				a {
 					text-wrap: nowrap;


### PR DESCRIPTION
Resolves #91 

Very simple! Just adds a new button under the 'Admin' dropdown for the django admin panel. Also redoes the styling of the admin dropdown since it felt a bit strange before, and having it horizontal was starting to make it very long with 'Django Admin' added to it.

<img width="151" height="217" alt="image" src="https://github.com/user-attachments/assets/17a2174b-8339-4752-a925-41adf6bfdbe5" />
