### PR TITLE
Implement /scores/<inst_id>/

### DIFF
--- a/app/api/views/scores.py
+++ b/app/api/views/scores.py
@@ -80,7 +80,7 @@ class ScoresView(APIView):
                 scores.append(
                     {
                         "id": play.id,
-                        "created_at": int(play.created_at.timestamp()),
+                        "created_at": play.created_at.isoformat(),
                         "percent": details.get("overview", {}).get("score", 0),
                     }
                 )

--- a/app/materia/urls.py
+++ b/app/materia/urls.py
@@ -133,6 +133,11 @@ urlpatterns = [
         name="scores",
     ),
     path(
+        "scores/<slug:widget_instance_id>/",
+        ScoresView.as_view(),
+        name="scores",
+    ),
+    path(
         "scores/embed/<slug:widget_instance_id>/<slug:play_id>/",
         ScoresView.as_view(),
         name="scores",

--- a/src/components/score-page.jsx
+++ b/src/components/score-page.jsx
@@ -11,7 +11,7 @@ const ScorePage = () => {
 	let playID = null
 	let token = null
 
-	const urlElements = window.location.pathname.match(/\/scores\/(single\/)?(preview\/)?(embed\/)?([a-z0-9\-_]+)\/([a-z0-9\-_]+)/i)
+	const urlElements = window.location.pathname.match(/\/scores\/(single\/)?(preview\/)?(embed\/)?([a-z0-9\-_]+)(?:\/([a-z0-9\-_]+))?/i)
 	if (urlElements) {
 		isSingle = urlElements[1] == "single/"
 		isPreview = urlElements[2] == "preview/"
@@ -61,7 +61,7 @@ const ScorePage = () => {
 
 	let bodyRender = null
 	if (state.ready) {
-		bodyRender = <Scores 
+		bodyRender = <Scores
 		instID={state.instanceID}
 		playID={state.playID}
 		userID={state.userID}

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -182,6 +182,16 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 	},[instanceScores, instanceScoresError])
 
 	/*
+	Set initial attempt if no play id was passed in
+  */
+	useEffect(() => {
+		if (instance?.guest_access || isSingle || isPreview) return
+		if (!playID && !currentAttempt && !!attempts) {
+			setCurrentAttempt(attempts.length)
+		}
+	}, [playID, currentAttempt, attempts])
+
+	/*
 	Setup state information based on play data
 		- Score overview
 		- Score table (which is passed to score screen)
@@ -279,7 +289,7 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 				setPlayID(attempts[hash - 1].id)
 			}
 		}
-	},[currentAttempt])
+	}, [currentAttempt])
 
 	/*
 	send postMessage to the score screen frame

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -12,6 +12,7 @@ import './scores.scss'
 const STATE_RESTRICTED = 'restricted'
 const STATE_INVALID = 'invalid'
 const STATE_EXPIRED = 'expired'
+const STATE_NO_SCORES = 'no_scores'
 
 const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPreview, isSingle}) => {
 
@@ -146,8 +147,8 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 	*/
 	useEffect(() => {
 		if (!!instanceScores) {
-			if (instanceScores.length < 1) {
-				setErrorState(STATE_INVALID)
+			if (instanceScores.scores.length < 1) {
+				setErrorState(STATE_NO_SCORES)
 			} else {
 				const scores = Array.from(instanceScores.scores)
 				// Sort scores by created_at in ascending order (oldest first)
@@ -449,6 +450,21 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 							</ul>
 
 							<SupportInfo />
+						</section>
+					</div>
+				)
+				break
+			case STATE_NO_SCORES:
+				errorStateRender = (
+					<div className="no_scores container general">
+						<section className="page">
+							<h2 className="logo">No Scores</h2>
+							<p>
+								You don't have any scores recorded for this widget.
+							</p>
+							<p>
+								Play this widget to completion to record a score!
+							</p>
 						</section>
 					</div>
 				)

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -47,7 +47,7 @@ $preview-purple: #b944cc;
 		}
 	}
 
-	&.expired, &.invalid, &.score_restrict {
+	&.expired, &.invalid, &.score_restrict, &.no_scores {
 		min-height: 480px;
 		background: #fff;
 
@@ -80,6 +80,14 @@ $preview-purple: #b944cc;
 			.error-support {
 				padding-bottom: 1em;
 			}
+		}
+	}
+
+	&.no_scores {
+		min-height: unset;
+
+		.page {
+			padding-bottom: 1em;
 		}
 	}
 }
@@ -262,7 +270,7 @@ $preview-purple: #b944cc;
 
 	#overview-table {
 		background-color: $color-background-dark;
-		
+
 		table {
 			font-weight: 400;
 			color: #ccc;
@@ -439,7 +447,7 @@ article {
 							font-size: 0.9em;
 							font-weight: bold;
 						}
-		
+
 						.score {
 							color: #333;
 							font-weight: bold;


### PR DESCRIPTION
Resolves #92 

- Re-implements the `/scores/<inst_id>/` endpoint, which doesn't require the play ID. 
  - Displays all attempts for a user on that given instance, showing the most recent one first.
- Fixes the `/api/scores` endpoint to pass back an ISO8601 date format, rather than an int timestamp.
- Adds a 'no scores' screen that displays when a user attempts to access `/scores/<inst_id>/` but doesn't have any scores recorded.

<img width="868" height="258" alt="image" src="https://github.com/user-attachments/assets/80bab4e9-eddb-4fdb-8826-f65b838be352" />
