### PR TITLE
Better support for multiple registrations

### DIFF
--- a/app/lti/ags/client.py
+++ b/app/lti/ags/client.py
@@ -1,6 +1,8 @@
 import logging
 from datetime import datetime
 
+from lti.services.launch import LTILaunchService
+
 from .oauth import AGSOauth
 from .request import AGSRequest
 from .score_builder import AGSScoreBuilder
@@ -19,7 +21,10 @@ class AGSClient:
 
     def __init__(self, launch_data):
         self.launch_data = launch_data
-        self._oauth = AGSOauth()
+
+        registration = LTILaunchService.get_registration(self.launch_data)
+
+        self._oauth = AGSOauth(registration)
         self._access_token = None
         self._user_id = None
 

--- a/app/lti/ags/oauth.py
+++ b/app/lti/ags/oauth.py
@@ -4,7 +4,6 @@ import uuid
 
 import jwt
 import requests
-from django.conf import settings
 from lti_tool.models import Key, LtiRegistration
 
 logger = logging.getLogger("django")
@@ -12,15 +11,10 @@ logger = logging.getLogger("django")
 
 class AGSOauth:
 
-    def __init__(self, scope=None):
+    def __init__(self, registration: LtiRegistration, scope=None):
         """
-        Initialize the OAuth2 handler.
+        Initialize the OAuth2 handler. Requires an LtiRegistration model instance to be provided.
         """
-        platform_domain = settings.LTI_URL_CONFIGS["platform_domain"]
-        registration = LtiRegistration.objects.filter(
-            token_url__contains=platform_domain
-        ).first()
-
         self.client_id = registration.client_id
         self.issuer = registration.issuer
         self.token_url = registration.token_url

--- a/app/lti/services/launch.py
+++ b/app/lti/services/launch.py
@@ -66,6 +66,7 @@ class LTILaunchService:
                 new_association.save()
             return new_association
 
+    @staticmethod
     def get_resource_link(launch_data):
         resource_link_claim = launch_data.get(
             "https://purl.imsglobal.org/spec/lti/claim/resource_link", None
@@ -76,6 +77,7 @@ class LTILaunchService:
             else None
         )
 
+    @staticmethod
     def get_resource_link_1p1(launch_data):
         lti_1p1_claim = launch_data.get(
             "https://purl.imsglobal.org/spec/lti/claim/lti1p1", None
@@ -86,10 +88,17 @@ class LTILaunchService:
             else None
         )
 
+    @staticmethod
     def get_deployment(launch_data):
         return launch_data.get(
             "https://purl.imsglobal.org/spec/lti/claim/deployment_id", None
         )
+
+    @staticmethod
+    def get_registration(launch_data):
+        deployment_id = LTILaunchService.get_deployment(launch_data)
+        deployment = LtiDeployment.objects.get(deployment_id=deployment_id)
+        return deployment.registration if deployment is not None else None
 
     @staticmethod
     def get_launch_redirect(launch_data):

--- a/app/lti/urls.py
+++ b/app/lti/urls.py
@@ -22,7 +22,7 @@ urlpatterns = [
         MateriaOIDCLoginInitView.as_view(),
         name="init",
     ),
-    path("lticonfig/", lti_config, name="lti_config"),
+    path("lticonfig/<slug:provider>", lti_config, name="lti_config"),
     path("ltilaunch/", ApplicationLaunchView.as_view(), name="ltilaunch"),
     path("lti/error/", error_page, name="error_page"),
 ]

--- a/app/lti/urls.py
+++ b/app/lti/urls.py
@@ -1,4 +1,5 @@
 from django.urls import path
+from django.views.generic import RedirectView
 from lti.views.config import lti_config
 from lti.views.deep_linking import lti_deep_link_selection
 from lti.views.init import MateriaOIDCLoginInitView
@@ -21,6 +22,11 @@ urlpatterns = [
         "init/<uuid:registration_uuid>/",
         MateriaOIDCLoginInitView.as_view(),
         name="init",
+    ),
+    path(
+        "lticonfig/",
+        RedirectView.as_view(url="/404", permanent=False),
+        name="lti_config_no_provider",
     ),
     path("lticonfig/<slug:provider>", lti_config, name="lti_config"),
     path("ltilaunch/", ApplicationLaunchView.as_view(), name="ltilaunch"),

--- a/app/lti/views/config.py
+++ b/app/lti/views/config.py
@@ -3,29 +3,26 @@ from urllib.parse import urlparse
 
 from django.conf import settings
 from django.http import JsonResponse
+from django.shortcuts import redirect
 from django.template.loader import render_to_string
 from lti_tool.models import LtiRegistration
 
 
 def lti_config(request, provider):
     """
-    The LTI config is currently configured to render values associated with a single registration
-    based on the matching platform_domain value written to env vars
-    While the underlying django-lti package supports multiple registrations,
-    the system is not currently built to support them.
+    Renders the LTI config JSON for the given provider.
+    The JSON config is registration-specific, and we map registrations to providers using
+    the registration name value. Requests that don't include a provider string or use a string
+    that fails to map to a registration are redirected to /404.
     """
 
+    # domain is the tool (your instance of Materia) URL, NOT the provider domain
     domain = urlparse(settings.LTI_URL_CONFIGS["tool_url"]).netloc or "localhost"
 
     try:
-        # Get registration by token_url domain that matches platform_domain env var
         registration = LtiRegistration.objects.filter(name__icontains=provider).first()
-        registration_uuid = (
-            registration.uuid if registration else "insert-registration-uuid-here"
-        )
-    except Exception as e:
-        print(f"Error getting registration: {e}")
-        registration_uuid = "insert-registration-uuid-here"
+    except Exception:
+        return redirect("/404")
 
     json_template = render_to_string(
         "lti.json",
@@ -33,7 +30,7 @@ def lti_config(request, provider):
             "app_hostname": settings.LTI_URL_CONFIGS["tool_url"] or "localhost",
             "platform": registration.issuer,
             "app_domain": domain,
-            "registration_uuid": registration_uuid,
+            "registration_uuid": registration.uuid,
         },
     )
 

--- a/app/lti/views/config.py
+++ b/app/lti/views/config.py
@@ -7,21 +7,19 @@ from django.template.loader import render_to_string
 from lti_tool.models import LtiRegistration
 
 
-def lti_config(request):
+def lti_config(request, provider):
     """
     The LTI config is currently configured to render values associated with a single registration
     based on the matching platform_domain value written to env vars
     While the underlying django-lti package supports multiple registrations,
     the system is not currently built to support them.
     """
+
     domain = urlparse(settings.LTI_URL_CONFIGS["tool_url"]).netloc or "localhost"
-    platform_domain = settings.LTI_URL_CONFIGS["platform_domain"]
 
     try:
         # Get registration by token_url domain that matches platform_domain env var
-        registration = LtiRegistration.objects.filter(
-            token_url__contains=platform_domain
-        ).first()
+        registration = LtiRegistration.objects.filter(name__icontains=provider).first()
         registration_uuid = (
             registration.uuid if registration else "insert-registration-uuid-here"
         )
@@ -33,8 +31,7 @@ def lti_config(request):
         "lti.json",
         {
             "app_hostname": settings.LTI_URL_CONFIGS["tool_url"] or "localhost",
-            "platform": settings.LTI_URL_CONFIGS["platform_iss"]
-            or "https://canvas.instructure.com",
+            "platform": registration.issuer,
             "app_domain": domain,
             "registration_uuid": registration_uuid,
         },

--- a/app/materia/settings/lti.py
+++ b/app/materia/settings/lti.py
@@ -32,6 +32,4 @@ LTI_SAVE_ASSOCIATIONS = True
 
 LTI_URL_CONFIGS = {
     "tool_url": os.environ.get("BASE_URL", "").rstrip("/"),
-    "platform_iss": os.environ.get("PLATFORM_ISS"),
-    "platform_domain": os.environ.get("PLATFORM_DOMAIN"),
 }

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -74,10 +74,6 @@ ASSET_STORAGE_S3_ENDPOINT=""
 
 # === LTI CONFIGURATION ====================================
 
-# These values are used to populate the dynamically generated /lticonfig
-PLATFORM_DOMAIN=""
-PLATFORM_ISS=""
-
 # Where do we grab the institutional user ID from the LTI payload?
 # If claim is an empty string, the identifier will be referenced at the top level
 LTI_PAYLOAD_USER_CLAIM="https://purl.imsglobal.org/spec/lti/claim/lis"


### PR DESCRIPTION
Updates the `/lticonfig` view to support multiple registrations: the `/lticonfig` view is no longer provider-agnostic, and a specific provider must be specified, e.g., `/lticonfig/ucf` or `/lticonfig/obojobo`. The provider string is matched to a registration's `name` field, so registrations should use url-safe string values for `name`.

Retired the `PLATFORM_DOMAIN` and `PLATFORM_ISS` env vars and replaced references to them as necessary in the `lti_config` view as well as the `AGSOauth` class. `AGSOauth` now requires an `LtiRegistration` model instance to be passed in as a parameter, which isn't a big deal because it's only used in `AGSClient` which has access to launch data. These have been updated accordingly.

Added a `get_registration` static method to the `LTILaunchService` to quickly acquire the associated `LtiRegistration` model instance from launch data and added missing `@staticmethod` decorators to the other `LTILaunchService` methods.