### PR TITLE
Widget Sync Command

### DIFF
--- a/app/core/management/commands/post-install.py
+++ b/app/core/management/commands/post-install.py
@@ -123,6 +123,18 @@ class Command(base.BaseCommand):
 
         By default, this command specifically targets UCF-created Materia widgets
         A separate .json file containing clean_name -> repo pairings can be passed in to use as well.
+        The JSON should look something like:
+        {
+            "my-widget": "github/repo",  // automatically assumed to use 'github' update method
+            "my-other-widget": {  // use a dict for non-github update methods
+                "method": "method that is not github",
+                "params": {
+                    // parameters that will get inserted into the metadata
+                    // for 'github', that would be 'repo'
+                    "other-param": "value"
+                }
+            }
+        }
         """
 
         # Determine target widgets

--- a/app/core/management/commands/post-install.py
+++ b/app/core/management/commands/post-install.py
@@ -1,4 +1,5 @@
 import logging
+import json
 import re
 import traceback
 
@@ -115,49 +116,68 @@ class Command(base.BaseCommand):
 
             year_counter = year_counter + 1
 
-    def sync_widgets(self):
+    def sync_widgets(self, sync_file=None):
         """
         Updates currently installed widgets that do not have update support enabled to the latest version.
         Latest versions will have the new python score modules, and update support enabled.
 
-        This command specifically targets UCF-created Materia widgets
+        By default, this command specifically targets UCF-created Materia widgets
+        A separate .json file containing clean_name -> repo pairings can be passed in to use as well.
         """
 
-        target_widgets = {
-            # TODO - update this list to match all widgets we are bringing into the django world
-            #      - also, some of these widgets are in private repos (ucdcdl)
-            "adventure": "ucfopen/adventure-materia-widget",
-            # "associations": "ucfcdl/associations-materia-widget",
-            # "category-climb": "ucfcdl/category-climb-materia-widget",
-            "crossword": "ucfopen/crossword-materia-widget",
-            "enigma": "ucfopen/enigma-materia-widget",
-            "equation-sandbox": "ucfopen/equation-sandbox-materia-widget",
-            "flash-cards": "ucfopen/flash-cards-materia-widget",
-            "guess-the-phrase": "ucfopen/guess-the-phrase-materia-widget",
-            "labeling": "ucfopen/labeling-materia-widget",
-            "last-chance-cadet": "ucfopen/last-chance-cadet-materia-widget",
-            "matching": "ucfopen/matching-materia-widget",
-            # "node-graph": "ucfcdl/node-graph-widget",
-            "normal-distribution-calculator": "ucfopen/normal-distribution-calculator-materia-widget",
-            "nursing-simulation-builder": "ucfopen/nursing-space-simulator-materia-widget",
-            "privilege-walk": "ucfopen/privilege-walk-materia-widget",
-            "proof-reading-symbols": "ucfopen/proof-reading-symbols-materia-widget",
-            "radar-grapher": "ucfopen/radar-grapher-materia-widget",
-            "secret-spreadsheet": "ucfopen/secret-spreadsheet-materia-widget",
-            "sequencer": "ucfopen/sequencer-materia-widget",
-            "simple-survey": "ucfopen/survey-materia-widget",
-            "slope-finder": "ucfopen/slope-finder-materia-widget",
-            "sort-it-out": "ucfopen/sort-it-out-materia-widget",
-            "syntax-sorter": "ucfopen/syntax-sorter-materia-widget",
-            "this-or-that": "ucfopen/this-or-that-materia-widget",
-            "word-search": "ucfopen/word-search-materia-widget",
-            "be-finder": "ucfopen/be-finder-materia-widget",
-            "concentration": "ucfopen/active-voice-verb-concentration-materia-widget",
-            "dodgeball": "ucfopen/infinity-dodgeball-materia-widget",
-            "roulette": "ucfopen/adverbial-clause-roulette-materia-widget",
-            "word-guess": "ucfopen/word-guess-materia-widget",
-        }
+        # Determine target widgets
+        if sync_file is not None:
+            # Load in sync file and use that instead of the default list
+            print(f"Using custom sync file: {sync_file}")
+            with open(sync_file, "r") as f:
+                try:
+                    target_widgets = json.loads(f.read())
+                except Exception as e:
+                    print(
+                        f"Error parsing custom sync file - it is likely not valid JSON: {e}"
+                    )
+                    traceback.print_exc()
+                    return
+        else:
+            # Use default list
+            print("Using default sync file")
 
+            target_widgets = {
+                # TODO - update this list to match all widgets we are bringing into the django world
+                #      - also, some of these widgets are in private repos (ucfcdl)
+                "adventure": "ucfopen/adventure-materia-widget",
+                # "associations": "ucfcdl/associations-materia-widget",
+                # "category-climb": "ucfcdl/category-climb-materia-widget",
+                "crossword": "ucfopen/crossword-materia-widget",
+                "enigma": "ucfopen/enigma-materia-widget",
+                "equation-sandbox": "ucfopen/equation-sandbox-materia-widget",
+                "flash-cards": "ucfopen/flash-cards-materia-widget",
+                "guess-the-phrase": "ucfopen/guess-the-phrase-materia-widget",
+                "labeling": "ucfopen/labeling-materia-widget",
+                "last-chance-cadet": "ucfopen/last-chance-cadet-materia-widget",
+                "matching": "ucfopen/matching-materia-widget",
+                # "node-graph": "ucfcdl/node-graph-widget",
+                "normal-distribution-calculator": "ucfopen/normal-distribution-calculator-materia-widget",
+                "nursing-simulation-builder": "ucfopen/nursing-space-simulator-materia-widget",
+                "privilege-walk": "ucfopen/privilege-walk-materia-widget",
+                "proof-reading-symbols": "ucfopen/proof-reading-symbols-materia-widget",
+                "radar-grapher": "ucfopen/radar-grapher-materia-widget",
+                "secret-spreadsheet": "ucfopen/secret-spreadsheet-materia-widget",
+                "sequencer": "ucfopen/sequencer-materia-widget",
+                "simple-survey": "ucfopen/survey-materia-widget",
+                "slope-finder": "ucfopen/slope-finder-materia-widget",
+                "sort-it-out": "ucfopen/sort-it-out-materia-widget",
+                "syntax-sorter": "ucfopen/syntax-sorter-materia-widget",
+                "this-or-that": "ucfopen/this-or-that-materia-widget",
+                "word-search": "ucfopen/word-search-materia-widget",
+                "be-finder": "ucfopen/be-finder-materia-widget",
+                "concentration": "ucfopen/active-voice-verb-concentration-materia-widget",
+                "dodgeball": "ucfopen/infinity-dodgeball-materia-widget",
+                "roulette": "ucfopen/adverbial-clause-roulette-materia-widget",
+                "word-guess": "ucfopen/word-guess-materia-widget",
+            }
+
+        # Start update process - go through each widget
         widgets = Widget.objects.all()
 
         no_matches = []
@@ -165,7 +185,7 @@ class Command(base.BaseCommand):
         failed_updates = []
 
         for widget in widgets:
-            # See if widget is in out list of updatable widgets
+            # See if widget is in our list of updatable widgets
             print()
             print(f"Syncing {widget.name} ({widget.id})...")
             if widget.clean_name not in target_widgets.keys():
@@ -174,8 +194,21 @@ class Command(base.BaseCommand):
                 continue
 
             print(" -> Is a syncable widget! Injecting update metadata...")
-            widget.metadata["update_method"] = "github"
-            widget.metadata["repo"] = target_widgets[widget.clean_name]
+            update_metadata = target_widgets[widget.clean_name]
+            if isinstance(update_metadata, str):
+                # When update_metadata is just a string, it's assumed it is just a github repo
+                widget.metadata["update_method"] = "github"
+                widget.metadata["repo"] = update_metadata
+            elif isinstance(update_metadata, dict):
+                # Otherwise, when it's an object, allow for custom needs
+                widget.metadata["update_method"] = update_metadata["method"]
+                for key, value in update_metadata["params"].items():
+                    widget.metadata[key] = value
+            else:
+                print(" -> Invalid update metadata, skipping")
+                failed_updates.append((widget.id, widget.name))
+                continue
+
             widget.save()
 
             print(" -> Getting latest version... ", end="")
@@ -193,15 +226,16 @@ class Command(base.BaseCommand):
                 print(" -> Done!")
                 synced.append((widget.id, widget.name))
             except MsgException as e:
-                print(" -> Failed to update:")
-                print(f"      - {e.title}")
-                print(f"      - {e.msg}")
+                print("Failed to update:")
+                print(f"     - {e.title}")
+                print(f"     - {e.msg}")
                 failed_updates.append((widget.id, widget.name))
             except Exception:
                 failed_updates.append((widget.id, widget.name))
-                print("\n -> Failed to update, traceback follows")
+                print("Failed to update, traceback follows")
                 traceback.print_exc()
 
+        # Print summary
         print("\nFinished syncing widgets! Results:")
 
         print("\nThe following widgets were synced successfully:")

--- a/app/core/management/commands/post-install.py
+++ b/app/core/management/commands/post-install.py
@@ -1,10 +1,16 @@
 import logging
 import re
+import traceback
 
 from dateutil import parser, tz
 from django.conf import settings
 from django.contrib.auth.models import Group
 from django.core.management import base
+
+from core.management.commands.widget import Command as WidgetCommand
+from core.message_exception import MsgException
+from core.models import Widget
+from core.services.widget_installer_service import WidgetInstallerService
 
 logger = logging.getLogger("django")
 
@@ -108,3 +114,104 @@ class Command(base.BaseCommand):
                     print(e)
 
             year_counter = year_counter + 1
+
+    def sync_widgets(self):
+        """
+        Updates currently installed widgets that do not have update support enabled to the latest version.
+        Latest versions will have the new python score modules, and update support enabled.
+
+        This command specifically targets UCF-created Materia widgets
+        """
+
+        target_widgets = {
+            # TODO - update this list to match all widgets we are bringing into the django world
+            #      - also, some of these widgets are in private repos (ucdcdl)
+            "adventure": "ucfopen/adventure-materia-widget",
+            # "associations": "ucfcdl/associations-materia-widget",
+            # "category-climb": "ucfcdl/category-climb-materia-widget",
+            "crossword": "ucfopen/crossword-materia-widget",
+            "enigma": "ucfopen/enigma-materia-widget",
+            "equation-sandbox": "ucfopen/equation-sandbox-materia-widget",
+            "flash-cards": "ucfopen/flash-cards-materia-widget",
+            "guess-the-phrase": "ucfopen/guess-the-phrase-materia-widget",
+            "labeling": "ucfopen/labeling-materia-widget",
+            "last-chance-cadet": "ucfopen/last-chance-cadet-materia-widget",
+            "matching": "ucfopen/matching-materia-widget",
+            # "node-graph": "ucfcdl/node-graph-widget",
+            "normal-distribution-calculator": "ucfopen/normal-distribution-calculator-materia-widget",
+            "nursing-simulation-builder": "ucfopen/nursing-space-simulator-materia-widget",
+            "privilege-walk": "ucfopen/privilege-walk-materia-widget",
+            "proof-reading-symbols": "ucfopen/proof-reading-symbols-materia-widget",
+            "radar-grapher": "ucfopen/radar-grapher-materia-widget",
+            "secret-spreadsheet": "ucfopen/secret-spreadsheet-materia-widget",
+            "sequencer": "ucfopen/sequencer-materia-widget",
+            "simple-survey": "ucfopen/survey-materia-widget",
+            "slope-finder": "ucfopen/slope-finder-materia-widget",
+            "sort-it-out": "ucfopen/sort-it-out-materia-widget",
+            "syntax-sorter": "ucfopen/syntax-sorter-materia-widget",
+            "this-or-that": "ucfopen/this-or-that-materia-widget",
+            "word-search": "ucfopen/word-search-materia-widget",
+            "be-finder": "ucfopen/be-finder-materia-widget",
+            "concentration": "ucfopen/active-voice-verb-concentration-materia-widget",
+            "dodgeball": "ucfopen/infinity-dodgeball-materia-widget",
+            "roulette": "ucfopen/adverbial-clause-roulette-materia-widget",
+            "word-guess": "ucfopen/word-guess-materia-widget",
+        }
+
+        widgets = Widget.objects.all()
+
+        no_matches = []
+        synced = []
+        failed_updates = []
+
+        for widget in widgets:
+            # See if widget is in out list of updatable widgets
+            print()
+            print(f"Syncing {widget.name} ({widget.id})...")
+            if widget.clean_name not in target_widgets.keys():
+                print(" -> Not an updatable widget, skipping")
+                no_matches.append((widget.id, widget.name))
+                continue
+
+            print(" -> Is a syncable widget! Injecting update metadata...")
+            widget.metadata["update_method"] = "github"
+            widget.metadata["repo"] = target_widgets[widget.clean_name]
+            widget.save()
+
+            print(" -> Getting latest version... ", end="")
+            try:
+                # Get latest version and links
+                new_ver, wigt_link, checksum_link = (
+                    WidgetInstallerService.get_latest_version_for(widget.id)
+                )
+                print(new_ver)
+
+                # Install latest version
+                print(" -> Updating...")
+                widget_command = WidgetCommand()
+                widget_command.install_from_url(wigt_link, checksum_link, widget.id)
+                print(" -> Done!")
+                synced.append((widget.id, widget.name))
+            except MsgException as e:
+                print(" -> Failed to update:")
+                print(f"      - {e.title}")
+                print(f"      - {e.msg}")
+                failed_updates.append((widget.id, widget.name))
+            except Exception:
+                failed_updates.append((widget.id, widget.name))
+                print("\n -> Failed to update, traceback follows")
+                traceback.print_exc()
+
+        print("\nFinished syncing widgets! Results:")
+
+        print("\nThe following widgets were synced successfully:")
+        for widget_id, widget_name in synced:
+            print(f" - {widget_name} ({widget_id})")
+
+        print("\nThe following widgets could be synced, but failed:")
+        for widget_id, widget_name in failed_updates:
+            print(f" - {widget_name} ({widget_id})")
+
+        print("\nThe following widgets were not eligible for sync:")
+        for widget_id, widget_name in no_matches:
+            print(f" - {widget_name} ({widget_id})")


### PR DESCRIPTION
This PR adds a command `post-install sync_widgets`, which will go through, add update support to all supported widgets, and update them. The goal here is to:
- Insert update metadata into existing widgets in the Widget table so that we can update them
- Update those widgets so that they have the python score modules

The 'syncing' functionality depends on the variable `target_widgets` defined in the `sync_widget` command, which links every supported widget's `clean_name` to its Github repo. This list should be updated once we have a final list of widgets we decide to bring into the Django world. The list also contains some commented-out `ucfcdl` widgets that have private repos.

New: Additionally, users can pass in their own `sync_file` to the command. This file should be JSON, and can be flexible to support both the default `github` method, as well as any others, with as many supporting parameters as needed. I've included the basic formatting for this JSON in the `sync_file` docstring.