### PR TITLE
Default Creator + Score Module-less Widgets

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -5,6 +5,8 @@ import json
 import logging
 import os
 
+from django.conf import settings
+
 from core.models import (
     Asset,
     DateRange,
@@ -164,6 +166,17 @@ class WidgetMetadataDictField(serializers.Field):
 class WidgetSerializer(serializers.ModelSerializer):
     meta_data = serializers.JSONField(source="metadata", required=False)
     dir = serializers.CharField(read_only=True)
+    creator = serializers.SerializerMethodField()
+
+    def get_creator(self, widget):
+        """
+        Checks if the widget uses the default creator - if so, returns the path for that
+        Otherwise, returns the value the widget has set.
+        """
+        if widget.creator == "default" or widget.creator == "":
+            return settings.URLS["STATIC_CROSSDOMAIN"] + "default-creator/creator.html"
+        else:
+            return widget.creator
 
     class Meta:
         model = Widget

--- a/app/core/management/commands/widget.py
+++ b/app/core/management/commands/widget.py
@@ -42,6 +42,9 @@ class Command(base.BaseCommand):
             if install_all or str(w["id"]) in list(args):
                 self.install_from_url(w["package"], w["checksum"], w["id"])
 
+    def install_from_file(self, wigt_location):
+        self.install(wigt_location)
+
     def install_from_url(self, package_url, checksum_url, desired_id=None):
         local_package = self.download_package(package_url)
         local_checksum = self.download_package(checksum_url)

--- a/app/core/services/widget_installer_service.py
+++ b/app/core/services/widget_installer_service.py
@@ -308,9 +308,7 @@ class WidgetInstallerService:
 
         # 5. Make sure the 'score' section is correct
         score = manifest_data["score"]
-        WidgetInstallerService.validate_keys_exist(
-            score, ["is_scorable", "score_module"]
-        )
+        WidgetInstallerService.validate_keys_exist(score, ["is_scorable"])
         WidgetInstallerService.validate_boolean_values(score, ["is_scorable"])
 
         # 6. Make sure the 'meta_data' section is correct
@@ -318,15 +316,21 @@ class WidgetInstallerService:
         WidgetInstallerService.validate_keys_exist(metadata, ["about", "excerpt"])
 
         # 7. Make sure the score_module.py/php ((test file?)and the score module test files both exist)
-        if not os.path.isfile(
-            os.path.join(dir, "_score-modules/score_module.php")
-        ) and not os.path.isfile(os.path.join(dir, "_score-modules/score_module.py")):
-            raise Exception("Missing score module file")
-        if not os.path.isfile(
-            os.path.join(dir, "_score-modules/test_score_module.php")
-        ):
-            # raise Exception("Missing score module tests")
-            print("missing tests...continuing")
+        if score["is_scorable"]:
+            WidgetInstallerService.validate_keys_exist(score, ["score_module"])
+
+            if not os.path.isfile(
+                os.path.join(dir, "_score-modules/score_module.php")
+            ) and not os.path.isfile(
+                os.path.join(dir, "_score-modules/score_module.py")
+            ):
+                raise Exception("Missing score module file")
+
+            if not os.path.isfile(
+                os.path.join(dir, "_score-modules/test_score_module.php")
+            ):
+                # raise Exception("Missing score module tests")
+                print("missing tests...continuing")
 
         return manifest_data
 
@@ -419,7 +423,11 @@ class WidgetInstallerService:
             "clean_name": clean_name,
             "api_version": int(manifest_data["general"]["api_version"]),
             "package_hash": package_hash,
-            "score_module": manifest_data["score"]["score_module"],
+            "score_module": (
+                manifest_data["score"]["score_module"]
+                if manifest_data["score"]["is_scorable"]
+                else ""
+            ),
             "is_generable": (
                 bool(manifest_data["general"]["is_generable"])
                 if "is_generable" in manifest_data["general"]

--- a/app/scoring/module.py
+++ b/app/scoring/module.py
@@ -3,6 +3,7 @@
 import logging
 from abc import ABC, abstractmethod
 
+from core.message_exception import MsgInvalidInput
 from core.models import Log, LogPlay
 
 logger = logging.getLogger(__name__)
@@ -111,7 +112,12 @@ class ScoreModule(ABC):
             elif log.log_type == Log.LogType.SCORE_WIDGET_INTERACTION:
                 self.handle_log_widget_interaction(log)
             elif log.log_type == Log.LogType.SCORE_PARTICIPATION:
-                self.verified_score = log.value
+                try:
+                    self.verified_score = int(log.value)
+                except ValueError:
+                    raise MsgInvalidInput(
+                        msg="Invalid participation log value - must be a number."
+                    )
 
     def handle_log_widget_interaction(self, log):
         """abstract method for handling widget interactions"""
@@ -276,4 +282,9 @@ class ScoreModule(ABC):
         This method is deprecated. Retaining the reference to prevent
         widget score modules from using it.
         """
+        pass
+
+
+class EmptyScoreModule(ScoreModule):
+    def check_answer(self, log):
         pass

--- a/app/scoring/module_factory.py
+++ b/app/scoring/module_factory.py
@@ -7,7 +7,7 @@ from typing import Optional, Type
 from django.utils import timezone
 
 from core.models import Log, LogPlay, User, WidgetInstance
-from scoring.module import ScoreModule
+from scoring.module import ScoreModule, EmptyScoreModule
 from core.services.semester_service import SemesterService
 
 logger = logging.getLogger(__name__)
@@ -19,6 +19,10 @@ class ScoreModuleFactory:
     def create_score_module(
         cls, instance: WidgetInstance, play: LogPlay
     ) -> Optional[ScoreModule]:
+
+        if not instance.widget.is_scorable:
+            # Return default empty score module if this widget isn't scorable
+            return EmptyScoreModule(play=play)
 
         try:
             widget_folder = f"staticfiles/widget/{instance.widget.id}-{instance.widget.clean_name}/_score-modules"


### PR DESCRIPTION
- Addresses #89 - which adds support back for the default creator used by some widgets.
- Adds the ability for widgets to be installed without score modules, when `is_scorable` is set to false.
  - During installation, the `score_module` metadata field is ignored if `is_scorable` is false.
  - When `is_scorable` is false, the scorer uses an empty default score module for the widget - just like how current unscorable widgets also use empty score modules themselves.
- Adds a `install_from_file` command to install .wigt files directly 