### PR TITLE
Fixes deleted widgets showing under widget catalog

### DIFF
--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -1,13 +1,12 @@
 import logging
 
 import django_filters
-
-from core.models import Asset, ObjectPermission, WidgetInstance, UserExtraAttempts
-from django.db.models import Q
-from rest_framework import filters
+from core.models import Asset, ObjectPermission, UserExtraAttempts, WidgetInstance
 from core.services.perm_service import PermService
 from core.services.semester_service import SemesterService
+from django.db.models import Q
 from django_filters import rest_framework
+from rest_framework import filters
 
 logger = logging.getLogger("django")
 
@@ -34,6 +33,7 @@ class UserInstanceFilterBackend(filters.BaseFilterBackend):
                 user,
                 [ObjectPermission.PERMISSION_FULL, ObjectPermission.PERMISSION_VISIBLE],
             )
+            queryset = queryset.filter(is_deleted=False)
         elif user_query is not None:
             if (
                 user.is_superuser


### PR DESCRIPTION
Fixes issue #110.

Updates the query in the widget catalog to filter out deleted widgets.

To test this, I deleted a few widgets through the widget catalog. Then, I refreshed and verified that the deleted widgets no longer appear under the widget catalog.