### PR TITLE
Creates permission gating for editing a widget to only users with full access and support users

### DIFF
--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -205,7 +205,6 @@ class WidgetPreviewView(MateriaLoginMixin, MateriaWidgetPlayProcessor, TemplateV
 
     def before_play_init(self, instance):
         preview = WidgetPlayInitService.init_preview(self.request)
-
         return {"play_id": preview, "lti_token": None}
 
 
@@ -223,6 +222,14 @@ class WidgetCreatorView(MateriaLoginMixin, PermissionRequiredMixin, TemplateView
         widget = Widget.objects.filter(pk=_get_id_from_slug(widget_slug)).first()
         if not widget:
             raise Http404("Could not find widget instance")
+
+        if instance_id is not None:
+            widget_instance = WidgetInstance.objects.get(id=instance_id)
+            can_edit = widget_instance.editable_by_current_user(self.request.user)
+            if not can_edit and not PermService.is_superuser_or_elevated(
+                self.request.user
+            ):
+                return _create_widget_no_permission_page(self.request)
 
         return _create_editor_page("Create Widget", widget, self.request)
 
@@ -422,6 +429,15 @@ def _create_widget_login_vars(
     }
 
     return js_globals
+
+
+def _create_widget_no_permission_page(request: HttpRequest):
+    return ContextUtil.create(
+        title="No Permission",
+        js_resources=settings.JS_GROUPS["no-permission"],
+        css_resources=settings.CSS_GROUPS["no-permission"],
+        request=request,
+    )
 
 
 def _create_draft_not_playable_page(request: HttpRequest):

--- a/src/components/my-widgets-selected-instance.jsx
+++ b/src/components/my-widgets-selected-instance.jsx
@@ -140,7 +140,7 @@ const MyWidgetSelectedInstance = ({
 
 	const onEditClick = inst => {
 		if (inst.widget.is_editable && state.perms.editable && editPerms && editPerms.can_edit && !permsFetching) {
-			const editUrl = `${window.location.origin}/widgets/${inst.widget.dir}create#${inst.id}`
+			const editUrl = `${window.location.origin}/widgets/${inst.widget.dir}create/${inst.id}`
 
 			if(editPerms.is_locked){
 				setShowLocked(true)
@@ -193,7 +193,7 @@ const MyWidgetSelectedInstance = ({
 	const deleteConfirmClickHandler = () => onDelete(inst)
 
 	const editWidget = () => {
-		const editUrl = window.location.origin + `/widgets/${inst.widget.dir}create#${inst.id}`
+		const editUrl = window.location.origin + `/widgets/${inst.widget.dir}create/${inst.id}`
 		window.location = editUrl
 	}
 

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -328,7 +328,7 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 				</div>
 				<div className='inst-action-buttons'>
 					<button className='action_button'
-						onClick={() => {window.location = `/widgets/${updatedInst.widget.dir}create#${updatedInst.id}`}}>
+						onClick={() => {window.location = `/widgets/${updatedInst.widget.dir}create/${updatedInst.id}`}}>
 						<span>Edit Widget</span>
 					</button>
 					<button className='action_button'

--- a/src/components/widget-creator-page.jsx
+++ b/src/components/widget-creator-page.jsx
@@ -19,7 +19,7 @@ const WidgetCreatorPage = () => {
 	const type = getWidgetType(window.location.pathname)
 	const pathParams = window.location.pathname.split('/')
 	const widgetID = pathParams[pathParams.length - 3].split('-')[0]
-	const instanceID = window.location.hash.substring(1)
+	const instanceID = pathParams[pathParams.length - 1]
 	const [state, setState] = useState({
 		widgetHeight: 0,
 		widgetWidth: 0,

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -478,6 +478,11 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 					case 'save':
 						setSaveWidgetComplete(saveModeRef.current)
 						if (!instIdRef.current) instIdRef.current = inst.id
+
+						const parts = window.location.pathname.split('/');
+						parts[parts.length - 1] = inst.id;
+						window.history.replaceState(null, '', parts.join('/'));
+
 						setInstance(currentInstance => ({ ...currentInstance, ...inst }))
 						apiGetQuestionSet(inst.id).then((qset) => {
 							sendToCreator('onSaveComplete', [


### PR DESCRIPTION
This PR fixes #98 and fixes #97.

In the PHP version, permission gating did not happen until the user was in the edit widget page. Now, permission gating occurs as the request to the page is made. To do this, I now send over the widget instance ID and check that the user making the request has Full access to this widget instance, is a support user, or is an admin. If the user does not satisfy any of these checks, I redirect the user to the no-permission view.

**Testing**

- I created two accounts, A and B. I created a widget on A, copied the edit widget URL (A_url). Then, logged in to account B and pasted A_url to ensure that I get redirected to the no permission page.
- I created a support user and ensured that I can edit a widget that I was not the owner of or have Full access.
- I tried saving a newly created widget to ensure the URL is populated with the instanceId in the URL and is not hashed.
- I edited the widget through the widget catalog to ensure that the existing widget is populated
- Ensured save history works as intended