### PR TITLE
Disallows copying for users with view scores access

### DIFF
--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -79,7 +79,10 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
 
         # must have (any) access to instance or elevated perms
         # TODO: question_sets can't be restricted in this way, but we may want more context-sensitive authorization
-        elif self.action == "copy" or self.action == "export_playdata":
+        elif self.action == "copy":
+            permission_classes = [HasFullPerms | IsSuperOrSupportUser]
+
+        elif self.action == "export_playdata":
             permission_classes = [HasAnyPerms | IsSuperOrSupportUser]
 
         elif self.action == "undelete":

--- a/src/util/raw-perms-to-object.js
+++ b/src/util/raw-perms-to-object.js
@@ -16,7 +16,7 @@ const rawPermsToObj = (perm, isEditable) => {
 		editable: perm.permission != access.VISIBLE && isEditable,
 		can: {
 			view: true, // implicit with all access types
-			copy: true, // implicit with all access types
+			copy: perm.permission == access.FULL,
 			edit: perm.permission == access.FULL,
 			delete: perm.permission == access.FULL,
 			share: perm.permission == access.FULL, // Refers to the ability to share with collaborators


### PR DESCRIPTION
Closes issue #118.

I updated the backend permissions for copying to only users with full access and added conditional copying on the frontend since copying is not an access that all users should have

**Testing**
- I tried copying to see if the backend would reject a user with only View Access permissions
- I ensured that "Make a Copy" is now greyed out and inaccessible to be clicked on the frontend