### PR TITLE
LTI role improvements

### DIFF
--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -162,7 +162,7 @@ class WidgetPlayView(
         if instance is None:
             return lti_error_page(request, "error_unknown_assignment")
 
-        if LTIAuthService.is_user_author(launch):
+        if LTIAuthService.is_user_course_author(launch):
             if instance.guest_access:
                 return lti_error_page(request, "error_lti_guest_mode")
             else:

--- a/app/lti/services/auth.py
+++ b/app/lti/services/auth.py
@@ -28,25 +28,60 @@ class LTIAuthService:
 
         for role in lti_roles:
             author_group = Group.objects.get(name="basic_author")
-            if role in settings.LTI_ROLES["staff"]:
+
+            # check for presence of instructor roles. Check both institution- and
+            # course-level roles.
+            if role in settings.LTI_INSTITUTION_ROLES["staff"]:
                 user.groups.add(author_group)
                 return True
 
-            if role in settings.LTI_ROLES["student"]:
+            if role in settings.LTI_COURSE_ROLES["staff"]:
+                user.groups.add(author_group)
+                return True
+
+            if role in settings.LTI_INSTITUTION_ROLES["student"]:
                 user.groups.remove(author_group)
                 return True
 
+            if role in settings.LTI_COURSE_ROLES["student"]:
+                user.groups.remove(author_group)
+                return True
+
+        # user does not possess any of the roles recognized as instructor or student
         logger.error(
             f"LTI auth: user does not have a known role or roles: {pformat(lti_roles)}"
         )
         return False
 
     @staticmethod
-    def is_user_author(launch):
+    def is_user_staff(launch):
+        """
+        Checks whether the user has the staff role for ANY context
+        An instructor may be a student in a course but will still possess
+        the staff role in the institution context.
+        """
         roles = launch.get("https://purl.imsglobal.org/spec/lti/claim/roles", [])
 
         for role in roles:
-            if role in settings.LTI_ROLES["staff"]:
+            if role in settings.LTI_COURSE_ROLES["staff"]:
+                return True
+
+            if role in settings.LTI_INSTITUTION_ROLES["staff"]:
+                return True
+
+        return False
+
+    @staticmethod
+    def is_user_course_author(launch):
+        """
+        Checks whether the user has the staff role for the current COURSE context
+        Even if someone is a staff member at the institution,
+        they may be a student in the current course
+        """
+        roles = launch.get("https://purl.imsglobal.org/spec/lti/claim/roles", [])
+
+        for role in roles:
+            if role in settings.LTI_COURSE_ROLES["staff"]:
                 return True
 
         return False

--- a/app/materia/settings/lti.py
+++ b/app/materia/settings/lti.py
@@ -13,17 +13,24 @@ LTI_USERDATA = {
     ),
 }
 
-LTI_ROLES = {
+LTI_COURSE_ROLES = {
     "staff": [
-        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator",
-        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
         "http://purl.imsglobal.org/vocab/lis/v2/membership#Instructor",
         "http://purl.imsglobal.org/vocab/lis/v2/membership/Instructor#TeachingAssistant",
         "http://purl.imsglobal.org/vocab/lis/v2/membership#ContentDeveloper",
     ],
     "student": [
-        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
         "http://purl.imsglobal.org/vocab/lis/v2/membership#Learner",
+    ],
+}
+
+LTI_INSTITUTION_ROLES = {
+    "staff": [
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Administrator",
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Instructor",
+    ],
+    "student": [
+        "http://purl.imsglobal.org/vocab/lis/v2/institution/person#Student",
     ],
 }
 


### PR DESCRIPTION
Potentially resolves a long-running quirk of role provisioning with LTI 1.1:

In PHP Materia, the system always defers to the LMS to determine a user's role in the system based on the role provided in the launch data. This meant that if an instructor interacted with content in a course where they are a student, the system would revoke the `basic_author` role and treat them as a student system-wide.

This PR uses the more detailed user roles provided by a LTI 1.3 claim to bifurcate role management: `LTI_ROLES` has been split into `LTI_COURSE_ROLES` and `LTI_INSTRUCTOR_ROLES` with the associated roles moved into each of the two.

When `provision_roles` is called during LTI auth, we check for _any_ staff role across institution and course contexts. This means that assuming the `institution` roles are present in the launch data, a staff member will always retain the `basic_author` role in Materia. When roles are checked during a widget play launch, only course roles are checked, ensuring the view content is rendered appropriately to the user's course role.