### PR TITLE
Fix score screen for demo plays, fix profile page

### DIFF
--- a/src/components/profile-page.jsx
+++ b/src/components/profile-page.jsx
@@ -19,7 +19,7 @@ const ProfilePage = () => {
 	let userActivity =  useGetPlaySessions("me", false)
 
 	const mounted = useRef(false)
-	const { data: currentUser, isFetching} = useQuery({
+	const { data: currentUser, isFetching } = useQuery({
 		queryKey: ['user', 'me'],
 		queryFn: ({ queryKey }) => {
 			const [_key, user] = queryKey
@@ -173,7 +173,7 @@ const ProfilePage = () => {
 
 					{userActivity?.hasNextPage ? (
 						<button className="show_more_activity action_button" onClick={_getMoreLogs}>
-							{isFetchingNextActivityPage ? (
+							{userActivity?.isFetching ? (
 								<span className="message_loading">Loading...</span>
 							) : (
 								<span>Show more</span>

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -58,6 +58,10 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 		staleTime: Infinity,
 	})
 
+  console.log("AAAA")
+  console.log(instanceIsLoading)
+  console.log(instance['guest_access'])
+
 	/*
 	Grab instance score data for a given user
 		Only requested for score screens displayed at end-of-play flow
@@ -68,7 +72,7 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 		queryFn: () => {
 			return apiGetWidgetInstanceScores(instID, userID)
 		},
-		enabled: !isPreview && !isSingle && !!userID && !!instID,
+		enabled: !isPreview && !isSingle && !instanceIsLoading && !instance['guest_access'] && !!userID && !!instID,
 		staleTime: Infinity,
 		refetchOnWindowFocus: false,
 		retry: false,

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -58,10 +58,6 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 		staleTime: Infinity,
 	})
 
-  console.log("AAAA")
-  console.log(instanceIsLoading)
-  console.log(instance['guest_access'])
-
 	/*
 	Grab instance score data for a given user
 		Only requested for score screens displayed at end-of-play flow


### PR DESCRIPTION
Very simple PR, addresses two issues:
- For demo plays, the score screen was not working, instead showing a 'no scores' page.
  - This is because the score screen page was attempting to get all scores overviews for the current user. Though because demo plays are anonymous, this call returned no scores, resulting in the 'no scores' screen.
  - Fixed this by adding an additional check to the score overview call to check if the current instance is a guest instance.
  - Current score details are still loaded by a separate query, based on the current playID in the URL (unchanged behavior)
- The profile page would not load due to an undefined variable `isFetchingNextActivityPage`
  - Changed to `userActivity?.isFetching`, which seems to be the right var