### PR TITLE
Enable login redirects, additional routes and extra settings.

### DIFF
--- a/app/core/views/login.py
+++ b/app/core/views/login.py
@@ -1,12 +1,24 @@
+import os
 import re
 
 from core.models import WidgetInstance
-from django.conf import settings
-from django.shortcuts import render
 from core.utils.context_util import ContextUtil
+from django.conf import settings
+from django.shortcuts import redirect, render
 
 
 def login(request):
+    # allow for custom authentication backend usage to launch from the regular /login route
+    custom_auth_redirect = os.environ.get("AUTH_LOGIN_ROUTE_OVERRIDE", False)
+    if custom_auth_redirect:
+        # also allow for explicitly bypassing the custom authentication backend
+        if "directlogin" in request.GET:
+            # do nothing, proceed with regular login handling
+            pass
+        else:
+            # redirect to authentication package login route
+            return redirect(custom_auth_redirect)
+
     js_globals = {}
 
     # Get login title

--- a/app/materia/settings/apps.py
+++ b/app/materia/settings/apps.py
@@ -1,0 +1,16 @@
+# Application definition
+
+INSTALLED_APPS = [
+    "django.contrib.admin",
+    "django.contrib.auth",
+    "django.contrib.contenttypes",
+    "django.contrib.sessions",
+    "django.contrib.messages",
+    "django.contrib.staticfiles",
+    "django_filters",
+    "rest_framework",
+    # apps
+    "core",
+    "lti_tool",
+    "lti",
+]

--- a/app/materia/settings/base.py
+++ b/app/materia/settings/base.py
@@ -1,8 +1,16 @@
 # BASE config file for Materia
 
+import os
 from pathlib import Path
 
+from core.utils.validator_util import ValidatorUtil
+
+from .apps import *  # noqa: F401, F403
 from .css import *  # noqa: F401, F403
+from .db import *  # noqa: F401, F403
+
+# empty by default - override with environment/implementation-specific settings
+from .extra import *  # noqa: F401, F403
 from .generation import *  # noqa: F401, F403
 from .js import *  # noqa: F401, F403
 from .lti import *  # noqa: F401, F403
@@ -45,24 +53,6 @@ DEBUG = True
 
 ALLOWED_HOSTS = ["*", "localhost", "127.0.0.1"]
 
-
-# Application definition
-
-INSTALLED_APPS = [
-    "django.contrib.admin",
-    "django.contrib.auth",
-    "django.contrib.contenttypes",
-    "django.contrib.sessions",
-    "django.contrib.messages",
-    "django.contrib.staticfiles",
-    "django_filters",
-    "rest_framework",
-    # apps
-    "core",
-    "lti_tool",
-    "lti",
-]
-
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework.authentication.SessionAuthentication",
@@ -104,21 +94,6 @@ TEMPLATES = [
 ]
 
 WSGI_APPLICATION = "materia.wsgi.application"
-
-
-# Database
-# https://docs.djangoproject.com/en/5.0/ref/settings/#databases
-
-DATABASES = {
-    "default": {
-        "ENGINE": "django.db.backends.mysql",
-        "NAME": os.environ.get("MYSQL_DATABASE"),
-        "USER": os.environ.get("MYSQL_USER"),
-        "PASSWORD": os.environ.get("MYSQL_PASSWORD"),
-        "HOST": os.environ.get("MYSQL_HOST"),
-        "PORT": os.environ.get("MYSQL_PORT"),
-    },
-}
 
 # Password validation
 # https://docs.djangoproject.com/en/5.0/ref/settings/#auth-password-validators

--- a/app/materia/settings/db.py
+++ b/app/materia/settings/db.py
@@ -1,0 +1,15 @@
+# Database
+# https://docs.djangoproject.com/en/5.0/ref/settings/#databases
+
+import os
+
+DATABASES = {
+    "default": {
+        "ENGINE": "django.db.backends.mysql",
+        "NAME": os.environ.get("MYSQL_DATABASE"),
+        "USER": os.environ.get("MYSQL_USER"),
+        "PASSWORD": os.environ.get("MYSQL_PASSWORD"),
+        "HOST": os.environ.get("MYSQL_HOST"),
+        "PORT": os.environ.get("MYSQL_PORT"),
+    },
+}

--- a/app/materia/settings/extra.py
+++ b/app/materia/settings/extra.py
@@ -1,0 +1,2 @@
+# configure any environment- or implementation-specific or otherwise
+#  nonstandard settings in this file

--- a/app/materia/urls.py
+++ b/app/materia/urls.py
@@ -36,6 +36,7 @@ from core.views.widget import (
     WidgetQsetGenerateView,
     WidgetQsetHistoryView,
 )
+from django.conf import settings
 from django.contrib import admin
 from django.urls import include, path, re_path
 from lti.urls import urlpatterns as lti_urlpatterns
@@ -170,6 +171,20 @@ urlpatterns = [
 ]
 
 urlpatterns.extend(lti_urlpatterns)
+
+# enable additional routes to be added from custom packages based on app settings
+try:
+    # this assumes/requires each package's routes to be defined as urlpatterns
+    #  that are importable from a given include path
+    # also assumes that they're all valid with an empty starting path, which isn't
+    #  great but at least allows this to work
+    package_routes = settings.ADDITIONAL_PACKAGE_URL_PATTERNS
+    if package_routes and len(package_routes) > 0:
+        for routes in package_routes:
+            urlpatterns.extend([path("", include(routes))])
+except AttributeError:
+    # the setting is optional and has no default value
+    pass
 
 handler403 = "core.views.exception_handlers.forbidden"
 handler404 = "core.views.main.handler404"

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -105,7 +105,7 @@ GENERATION_LOG_STATS=false
 # ALLOWED VALUES: true | false
 SEND_EMAILS=false
 # what email address should system mails come from?
-SYSTEM_EMAIL=
+SYSTEM_EMAIL=""
 EMAIL_BACKEND=""
 # ^ To use an SMTP backend, use "django.core.mail.backends.smtp.EmailBackend" and fill in the SMTP env vars below.
 #   To use a Sendgrid backend, use "sendgrid_backend.SendgridBackend" and fill in your Sendgrid API key in the env var below.
@@ -119,4 +119,9 @@ EMAIL_HOST_PASSWORD=""
 EMAIL_TIMEOUT=0
 
 # Sendgrid Backend Settings
-SENDGRID_API_KEY=
+SENDGRID_API_KEY=""
+
+# If using a non-standard authentication package or anything else that would
+#  redirect login attempts, set this to the desired URL to redirect to from
+#  "/login"
+AUTH_LOGIN_ROUTE_OVERRIDE=false


### PR DESCRIPTION
Closes #126.

Adds checks to login handling and URL pattern definitions to optionally allow for overrides that enable external auth package usage. Moved some settings into their own files to more easily override them per environment/implementation.