### PR TITLE
Updates collaborator list logic to guarantee at least one full access user

### DIFF
--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -21,7 +21,14 @@ from api.serializers import (
     WidgetInstanceSerializer,
 )
 from core.message_exception import MsgFailure, MsgInvalidInput
-from core.models import LogActivity, LogPlay, Notification, WidgetInstance, WidgetQset
+from core.models import (
+    LogActivity,
+    LogPlay,
+    Notification,
+    ObjectPermission,
+    WidgetInstance,
+    WidgetQset,
+)
 from core.services.instance_service import WidgetInstanceService
 from core.services.perm_service import PermService
 from core.services.play_data_exporter_service import PlayDataExporterService
@@ -325,9 +332,24 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
             request_serializer = PermsUpdateRequestListSerializer(data=request.data)
             request_serializer.is_valid(raise_exception=True)
 
-            # Go through each perm request and process it
             refusals = []
             updates = request_serializer.validated_data.get("updates", [])
+
+            # Don't update perms if user is the only full perm holder
+            full_perm_holders = [
+                update
+                for update in updates
+                if update["perm_level"] == ObjectPermission.PERMISSION_FULL
+            ]
+            if (
+                requester_perm == ObjectPermission.PERMISSION_FULL
+                and len(full_perm_holders) == 0
+            ):
+                raise MsgFailure(
+                    msg="Cannot remove permissions from the only full permission holder."
+                )
+
+            # Go through each perm request and process it
             for update in updates:
                 perm_level = update["perm_level"]
                 expiration = update["expiration"]
@@ -367,6 +389,14 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
                     user_existing_perm is not None
                     and PermService.compare_perms(requester_perm, user_existing_perm)
                     > 0
+                ):
+                    refusals.append(user)
+                    continue
+
+                # Make sure requester can't grant perms lower than their own
+                if (
+                    user == requester
+                    and PermService.compare_perms(requester_perm, perm_level) < 0
                 ):
                     refusals.append(user)
                     continue

--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -340,13 +340,13 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 					<div id='calendar-portal' />
 					<p className='disclaimer'>
 						Users with full access can edit or copy this widget and can
-						add or remove people in this list.
+						add or remove people in this list. 
+						{onlyOneFullPermHolder && myPerms.accessLevel == access.FULL && (
+							<em>
+								{'\u00A0'}Note: There must be at least one user with full access.
+							</em>
+						)}
 					</p>
-					{onlyOneFullPermHolder && myPerms.accessLevel == access.FULL && (
-						<p className='warning'>
-							Note: There must be at least one user with full access.
-						</p>
-					)}
 					<div className='btn-box'>
 						<a tabIndex='0'
 							className='cancel_button'

--- a/src/components/my-widgets-collaborate-dialog.jsx
+++ b/src/components/my-widgets-collaborate-dialog.jsx
@@ -260,6 +260,11 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 		)
 	}
 
+	const fullPermHolders = Array.from(state.updatedAllUserPerms.values())
+		.filter(u => u.accessLevel === access.FULL && !u.remove)
+		.length;
+	const onlyOneFullPermHolder = fullPermHolders === 1
+	const removedCurrentUser = state.updatedAllUserPerms.get(currentUser.id)?.remove === true
 	let mainContentRender = <LoadingIcon />
 	if (!isFetching) {
 		mainContentRender = <NoContentIcon />
@@ -282,6 +287,8 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 					perms={userPerms}
 					myPerms={myPerms}
 					isCurrentUser={currentUser.id === user.id}
+					onlyOneFullPermHolder={onlyOneFullPermHolder}
+					removedCurrentUser={removedCurrentUser}
 					onChange={(userId, perms) => updatePerms(userId, perms)}
 					readOnly={myPerms?.can?.share === false}
 				/>
@@ -335,6 +342,11 @@ const MyWidgetsCollaborateDialog = ({onClose, inst, myPerms, otherUserPerms, set
 						Users with full access can edit or copy this widget and can
 						add or remove people in this list.
 					</p>
+					{onlyOneFullPermHolder && myPerms.accessLevel == access.FULL && (
+						<p className='warning'>
+							Note: There must be at least one user with full access.
+						</p>
+					)}
 					<div className='btn-box'>
 						<a tabIndex='0'
 							className='cancel_button'

--- a/src/components/my-widgets-collaborate-dialog.scss
+++ b/src/components/my-widgets-collaborate-dialog.scss
@@ -167,6 +167,13 @@
 		margin-top: 10px;
 	}
 
+	.warning {
+		color: #FF9800;
+		font-weight: bold;
+		margin-top: 10px;
+		text-align: center;
+	}
+
 	.access-list {
 		.deleted {
 			display: none !important;

--- a/src/components/my-widgets-collaborate-dialog.scss
+++ b/src/components/my-widgets-collaborate-dialog.scss
@@ -6,6 +6,7 @@
 	box-sizing: border-box;
 
 	font-family: 'Lato', arial, serif;
+	font-weight: 400;
 
 	.title {
 		margin: 0;
@@ -168,10 +169,7 @@
 	}
 
 	.warning {
-		color: #FF9800;
 		font-weight: bold;
-		margin-top: 10px;
-		text-align: center;
 	}
 
 	.access-list {

--- a/src/components/my-widgets-collaborate-user-row.jsx
+++ b/src/components/my-widgets-collaborate-user-row.jsx
@@ -40,7 +40,7 @@ const CalendarContainer = ({children}) => {
 	)
 }
 
-const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onChange, readOnly}) => {
+const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onlyOneFullPermHolder, removedCurrentUser, onChange, readOnly}) => {
 	const [state, setState] = useState({...initRowState(), ...perms, expireDate: new Date(perms.expireTime)})
 	const ref = useRef()
 
@@ -126,10 +126,10 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onChange, read
 			)
 		} else {
 			expirationSettingRender = (
-				<button className={readOnly || isCurrentUser ? 'expire-open-button-disabled' : 'expire-open-button'}
+				<button className={readOnly || isCurrentUser || removedCurrentUser ? 'expire-open-button-disabled' : 'expire-open-button'}
 					data-testid={`${user.id}-never-expire`}
 					onClick={toggleShowExpire}
-					disabled={readOnly || isCurrentUser}>
+					disabled={readOnly || isCurrentUser || removedCurrentUser}>
 					Never
 				</button>
 			)
@@ -141,8 +141,8 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onChange, read
 			<button tabIndex='0'
 				onClick={checkForWarning}
 				className='remove'
-				disabled={readOnly && !isCurrentUser}
-				aria-hidden={readOnly && !isCurrentUser}
+				disabled={onlyOneFullPermHolder && (perms.accessLevel === access.FULL)}
+				aria-hidden={onlyOneFullPermHolder && (perms.accessLevel === access.FULL)}
 				data-testid={`${user.id}-delete-user`}>
 				X
 			</button>
@@ -156,7 +156,7 @@ const CollaborateUserRow = ({user, perms, myPerms, isCurrentUser, onChange, read
 			</div>
 			{ selfDemoteWarningRender }
 			<div className='options'>
-				<select disabled={readOnly}
+				<select disabled={readOnly || isCurrentUser || removedCurrentUser}
 					data-testid={`${user.id}-select`}
 					tabIndex='0'
 					className='perm'


### PR DESCRIPTION
This PR closes issue #117.

### Description
Updated actions in the collaborator list such that:
1. Users cannot demote themselves (Full -> View Scores)
2. There should be at least one user with Full Access to the widget
3. After removing yourself, you should not be able to perform any other updates, even if you had Full Access

### Testing
- Checks that when making an API request to demote yourself errors
- Checks the API request errors when trying to remove all full perm holders when you have full permission
- Ensured that the dropdown to demote yourself is disabled, but you can still demote other users if you have Full Access
- Ensures that “Note: There must be at least one user with full access” warning displays when you're the sole perm holder
- Checks that when removing yourself when you're the only Full Access holder would error
- Checks that after removing yourself, you won't be able to perform any other updates

