### PR TITLE
Fix AI generation

### DIFF
--- a/app/api/views/generation.py
+++ b/app/api/views/generation.py
@@ -74,7 +74,6 @@ class GenerateFromPromptView(APIView):
     http_method_names = ["post"]
     permission_classes = [CanCreateWidgetInstances]
 
-    @staticmethod
     def post(self, request):
         # Check if generation is available
         if not GenerationUtil.is_enabled():

--- a/app/core/management/commands/widget.py
+++ b/app/core/management/commands/widget.py
@@ -286,7 +286,6 @@ class Command(base.BaseCommand):
                 print(f"no score module for play: {play.id}")
                 return
 
-            module.validate_scores(in_process=False)
             details = module.get_score_report()
             scores.append(
                 {

--- a/app/core/message_exception.py
+++ b/app/core/message_exception.py
@@ -5,6 +5,7 @@
 from enum import Enum
 
 from django.http import HttpRequest, JsonResponse
+from rest_framework.exceptions import APIException
 from rest_framework.response import Response
 
 
@@ -14,7 +15,7 @@ class MsgSeverity(Enum):
     WARN = "warn"
 
 
-class MsgException(Exception):
+class MsgException(APIException):
     def __init__(
         self,
         title: str,
@@ -23,6 +24,7 @@ class MsgException(Exception):
         halt: bool = False,
         status: int = 403,
     ):
+        super().__init__(msg, status)
         self.title = title
         self.msg = msg
         self.severity = severity

--- a/app/core/services/generator_service.py
+++ b/app/core/services/generator_service.py
@@ -48,8 +48,8 @@ class GenerationUtil:
 
         # Grab custom prompt from the widget engine if it's available
         custom_engine_prompt = (
-            widget.meta_data["custom_engine_prompt"]
-            if "custom_engine_prompt" in widget.meta_data
+            widget.metadata["custom_engine_prompt"]
+            if "custom_engine_prompt" in widget.metadata
             else None
         )
 

--- a/src/components/question-generator.jsx
+++ b/src/components/question-generator.jsx
@@ -54,7 +54,7 @@ const QsetGenerator = () => {
 			topic,
 			includeImages,
 			numQuestions,
-			buildOffExisting,
+			buildOffExisting: (!!instId ? buildOffExisting : false),
 			successFunc: (result) => {
 				window.parent.Materia.Creator.onQsetReselectionComplete(
 					JSON.stringify(result.qset),
@@ -131,7 +131,7 @@ const QsetGenerator = () => {
 				</div> */}
 				<div id="build-off-existing-field">
 					<label htmlFor="build-off-existing">Keep current questions</label>
-					<input type="checkbox" id="build-off-existing" name="build-off-existing" onChange={(e) => setBuildOffExisting(e.target.checked)}/>
+					<input type="checkbox" id="build-off-existing" name="build-off-existing" disabled={!instId} onChange={(e) => setBuildOffExisting(e.target.checked)}/>
 					<span className="description">
 						If selected, generated content will be appended to existing content. If unselected, generated content will replace existing content.
 					</span>

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -492,7 +492,7 @@ export const apiUnDeleteWidget = ({ instId }) => {
 }
 
 export const apiWidgetPromptGenerate = (prompt) => {
-	return handleRequest(methods.POST, `/api/json/widget_prompt_generate/`,  prompt)
+	return handleRequest(methods.POST, `/api/generate/from_prompt/`, {prompt})
 }
 
 export const apiCheckWidgetForUpdate = (widgetId) => {


### PR DESCRIPTION
Resolves #137, which describes an issue with AI generation breaking with some recent changes.

Changelog:
- Changed `widget.meta_data` to `widget.metadata` in the generation service, reflecting some recent changes done to how widget metadata is handled. Fixes a crash that occurred in this service.
- Removed an erroneous `@staticmethod` decoration on one of the generation API views
- Fixed `api.js` to use the new API endpoint for prompt generation, instead of the old one
- Some other smaller misc fixes shoehorned in:
  - Removed double call of the score module in the `validate_plays_for_instance` command
  - `MsgException` now inherits `APIException` instead of just `Exception`, so it plays nicer with DRF