### PR TITLE
Makes waitForWindow less lame

### DIFF
--- a/src/components/closed.jsx
+++ b/src/components/closed.jsx
@@ -2,7 +2,8 @@ import React, {useEffect, useMemo, useState} from 'react';
 import Header from './header'
 import Summary from './widget-summary'
 import './login-page.scss'
-import EmbedFooter from './widget-embed-footer';
+import EmbedFooter from './widget-embed-footer'
+import { waitForWindow } from '../util/wait-for-window'
 
 const Closed = () => {
 
@@ -16,21 +17,8 @@ const Closed = () => {
 		end: ''
 	})
 
-	const waitForWindow = async () => {
-		while(!window.hasOwnProperty('IS_EMBEDDED')
-		&& !window.hasOwnProperty('NAME')
-		&& !window.hasOwnProperty('WIDGET_NAME')
-		&& !window.hasOwnProperty('ICON_DIR')
-		&& !window.hasOwnProperty('SUMMARY')
-		&& !window.hasOwnProperty('DESC')
-		&& !window.hasOwnProperty('START')
-		&& !window.hasOwnProperty('END')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
-
 	useEffect(() => {
-		waitForWindow()
+		waitForWindow(['IS_EMBEDDED', 'NAME', 'WIDGET_NAME', 'ICON_DIR', 'SUMMARY', 'DESC', 'START', 'END'])
 		.then(() => {
 			setState({
 				isEmbedded: window.IS_EMBEDDED,

--- a/src/components/detail.jsx
+++ b/src/components/detail.jsx
@@ -5,6 +5,7 @@ import DetailFeatureList from './detail-feature-list'
 import LoadingIcon from './loading-icon'
 import AccessibilityIndicator from './accessibility-indicator'
 import { WIDGET_URL } from './materia-constants'
+import { waitForWindow } from '../util/wait-for-window'
 
 const initWidgetData = () => ({
 	hasPlayerGuide: false,
@@ -94,18 +95,12 @@ const Detail = ({widget, isFetching}) => {
 
 	// Waits for window value to load from server then sets it
 	useEffect(() => {
-		waitForWindow()
+		waitForWindow(['NO_AUTHOR', 'WIDGET_HEIGHT'])
 		.then(() => {
-			setNoAuthor(window.NO_AUTHOR === '1' ? true : false)
-			setHeight(window.WIDGET_HEIGHT === '0' ? '' : window.WIDGET_HEIGHT) // Preloads height to avoid detail window resizing
+			setNoAuthor( !!window.NO_AUTHOR )
+			setHeight( window.WIDGET_HEIGHT == '0' ? '' : window.WIDGET_HEIGHT) // Preloads height to avoid detail window resizing
 		})
 	}, [])
-
-	// Used to wait for window data to load
-	const waitForWindow = async () => {
-		while(!window.hasOwnProperty('NO_AUTHOR') || !window.hasOwnProperty('WIDGET_HEIGHT'))
-			await new Promise(resolve => setTimeout(resolve, 500))
-	}
 
 	let iconRender = null
 	let contentRender = <div className='loading-icon-holder'><LoadingIcon size='lrg'/></div>

--- a/src/components/guide-page.jsx
+++ b/src/components/guide-page.jsx
@@ -1,62 +1,52 @@
 import React, { useState, useEffect} from 'react'
-import { useQuery } from 'react-query'
 import Header from './header'
 import './guide-page.scss'
+import { waitForWindow } from '../util/wait-for-window'
 
 const GuidePage = () => {
 
-  const [name, setName] = useState(null)
-  const [type, setType] = useState(null)
-  const [hasPlayerGuide, setHasPlayerGuide] = useState(null)
-  const [hasCreatorGuide, setHasCreatorGuide] = useState(null)
-  const [docPath, setDocPath] = useState(null)
+	const [name, setName] = useState(null)
+	const [type, setType] = useState(null)
+	const [hasPlayerGuide, setHasPlayerGuide] = useState(null)
+	const [hasCreatorGuide, setHasCreatorGuide] = useState(null)
+	const [docPath, setDocPath] = useState(null)
 
-  useEffect(() => {
-    waitForWindow().then(() => {
-      setName(window.NAME)
-      setType(window.TYPE)
-      setHasPlayerGuide(window.HAS_PLAYER_GUIDE)
-      setHasCreatorGuide(window.HAS_CREATOR_GUIDE)
-      setDocPath(window.DOC_PATH)
-    })
-  })
+	useEffect(() => {
+		waitForWindow(['NAME', 'TYPE', 'HAS_PLAYER_GUIDE', 'HAS_CREATOR_GUIDE', 'DOC_PATH']).then(() => {
+			setName(window.NAME)
+			setType(window.TYPE)
+			setHasPlayerGuide(window.HAS_PLAYER_GUIDE)
+			setHasCreatorGuide(window.HAS_CREATOR_GUIDE)
+			setDocPath(window.DOC_PATH)
+		})
+	})
 
-  const waitForWindow = async () => {
-		while(!window.hasOwnProperty('NAME')
-		&& !window.hasOwnProperty('TYPE')
-		&& !window.hasOwnProperty('HAS_PLAYER_GUIDE')
-		&& !window.hasOwnProperty('HAS_CREATOR_GUIDE')
-    && !window.hasOwnProperty('DOC_PATH')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
+	let headerRender = <Header />
+
+	let bodyRender = null
+	if (!!name) {
+		bodyRender = (
+			<section className="page">
+				<div id="top">
+					<h1>{ name }</h1>
+					<div id="guide-tabs" className={`${type}-guide`}>
+						{ hasPlayerGuide && <a href="../players-guide">Player Guide</a> }
+						{ hasCreatorGuide && <a href="../creators-guide">Creator Guide</a>}
+					</div>
+				</div>
+				<div id="guide-container">
+					<iframe src={ docPath } className="guide"></iframe>
+				</div>
+			</section>
+		)
 	}
 
-  let headerRender = <Header />
-
-  let bodyRender = null
-  if (!!name) {
-    bodyRender = (
-      <section className="page">
-      	<div id="top">
-      		<h1>{ name }</h1>
-      		<div id="guide-tabs" className={`${type}-guide`}>
-      			{ hasPlayerGuide && <a href="../players-guide">Player Guide</a> }
-      			{ hasCreatorGuide && <a href="../creators-guide">Creator Guide</a>}
-      		</div>
-      	</div>
-      	<div id="guide-container">
-      		<iframe src={ docPath } className="guide"></iframe>
-      	</div>
-      </section>
-    )
-  }
-
-  return (
-    <>
-    { headerRender }
-    { bodyRender }
-    </>
-  )
+	return (
+		<>
+		{ headerRender }
+		{ bodyRender }
+		</>
+	)
 }
 
 export default GuidePage

--- a/src/components/login-page.jsx
+++ b/src/components/login-page.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useRef, useState } from 'react'
 import { apiLoginDirect } from '../util/api'
+import { waitForWindow } from '../util/wait-for-window'
 
 import Header from './header'
 import Summary from './widget-summary'
@@ -20,17 +21,8 @@ const LoginPage = () => {
 		context: 'login',
 	})
 
-	const waitForWindow = async () => {
-		// window properties on the login page are highly variable, WFW can only watch for the default ones
-		while(!window.hasOwnProperty('BASE_URL')
-		&& !window.hasOwnProperty('WIDGET_URL')
-		&& !window.hasOwnProperty('STATIC_CROSSDOMAIN')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
-
 	useEffect(() => {
-		waitForWindow()
+		waitForWindow(['BASE_URL', 'WIDGET_URL', 'STATIC_CROSSDOMAIN'])
 		.then(() => {
 
 			let actionRedirect = window.location.search && window.location.search.split("?next=").length > 1 ? window.location.search.split("?next=")[1] : ''

--- a/src/components/logins-restricted-to-lms.jsx
+++ b/src/components/logins-restricted-to-lms.jsx
@@ -1,7 +1,9 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect } from 'react'
 import Header from './header'
 import Summary from './widget-summary'
-import EmbedFooter from './widget-embed-footer';
+import EmbedFooter from './widget-embed-footer'
+import { waitForWindow } from '../util/wait-for-window'
+
 
 const LoginsRestrictedToLMS = () => {
 
@@ -9,14 +11,8 @@ const LoginsRestrictedToLMS = () => {
 		context: ''
 	})
 
-	const waitForWindow = async () => {
-		while (!window.hasOwnProperty('CONTEXT')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
-
 	useEffect(() => {
-		waitForWindow()
+		waitForWindow(['CONTEXT'])
 		.then(() => {
 			setState({
 				context: window.CONTEXT,

--- a/src/components/lti/post-login.jsx
+++ b/src/components/lti/post-login.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useQuery } from 'react-query'
-import { waitForWindow } from '../util/wait-for-window'
+import { waitForWindow } from '../../util/wait-for-window'
 
 import { apiGetInstancesFromContext } from '../../util/api'
 import { iconUrl as getIconUrl } from '../../util/icon-url'

--- a/src/components/lti/post-login.jsx
+++ b/src/components/lti/post-login.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react'
 import { useQuery } from 'react-query'
+import { waitForWindow } from '../util/wait-for-window'
 
 import { apiGetInstancesFromContext } from '../../util/api'
 import { iconUrl as getIconUrl } from '../../util/icon-url'
@@ -9,20 +10,11 @@ const PostLogin = () => {
 	const [contextID, setContextID] = useState(null)
 
 	useEffect(() => {
-		waitForWindow().then(() => {
+		waitForWindow(['STATIC_CROSSDOMAIN', 'CONTEXT_ID']).then(() => {
 			setStaticURL(window.STATIC_CROSSDOMAIN)
 			setContextID(window.CONTEXT_ID)
 		})
 	}, [])
-
-	const waitForWindow = async () => {
-		while (
-			!window.hasOwnProperty('STATIC_CROSSDOMAIN') &&
-			!window.hasOwnProperty('CONTEXT_ID')
-		) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
 
 	const { isLoading, data: instances } = useQuery({
 		queryKey: ['lti-widgets', contextID],

--- a/src/components/no-attempts.jsx
+++ b/src/components/no-attempts.jsx
@@ -2,27 +2,20 @@ import React, { useState, useEffect} from 'react'
 import Summary from './widget-summary'
 import Header from './header'
 import EmbedFooter from './widget-embed-footer'
+import { waitForWindow } from '../util/wait-for-window'
 
 const NoAttempts = () => {
 	const [attempts, setAttempts] = useState(null)
 	const [scoresPath, setScoresPath] = useState(null)
 
 	useEffect(() => {
-	waitForWindow().then(() => {
-	const scoresPath = `/scores${window.IS_EMBEDDED ? '/embed' : ''}/${window.WIDGET_ID}`;
+		waitForWindow(['WIDGET_ID', 'IS_EMBEDDED', 'ATTEMPTS']).then(() => {
+		const scoresPath = `/scores${window.IS_EMBEDDED ? '/embed' : ''}/${window.WIDGET_ID}`;
 
-	setScoresPath(scoresPath);
-	setAttempts(window.ATTEMPTS)
-	})
-}, [])
-
-const waitForWindow = async () => {
-		while(!window.hasOwnProperty('WIDGET_ID')
-		&& !window.hasOwnProperty('IS_EMBEDDED')
-		&& !window.hasOwnProperty('ATTEMPTS')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
+		setScoresPath(scoresPath);
+		setAttempts(window.ATTEMPTS)
+		})
+	}, [])
 
 	let bodyRender = null
 	if (!!attempts) {

--- a/src/components/pre-embed-placeholder.jsx
+++ b/src/components/pre-embed-placeholder.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect} from 'react'
 import Summary from './widget-summary'
 import EmbedFooter from './widget-embed-footer'
+import { waitForWindow } from '../util/wait-for-window'
 
 import './pre-embed-common-styles.scss'
 
@@ -11,18 +12,11 @@ const PreEmbedPlaceholder = () => {
 	const [context, setContext] = useState(null)
 
 	useEffect(() => {
-		waitForWindow().then(() => {
+		waitForWindow(['INST_ID', 'CONTEXT']).then(() => {
 			setInstId(window.INST_ID)
 			setContext(window.CONTEXT)
 		})
 	})
-
-	const waitForWindow = async () => {
-		while(!window.hasOwnProperty('INST_ID')
-		&& !window.hasOwnProperty('CONTEXT')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
 
 	let bodyRender = null
 		bodyRender = (

--- a/src/components/retired.jsx
+++ b/src/components/retired.jsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react'
 import Header from './header'
+import { waitForWindow } from '../util/wait-for-window'
 
 const Retired = () => {
 
@@ -7,14 +8,8 @@ const Retired = () => {
 		isEmbedded: ''
 	})
 
-	const waitForWindow = async () => {
-		while(!window.hasOwnProperty('IS_EMBEDDED')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
-
 	useEffect(() => {
-		waitForWindow()
+		waitForWindow(['IS_EMBEDDED'])
 		.then(() => {
 			setState({
 				isEmbedded: window.IS_EMBEDDED

--- a/src/components/widget-player-page.jsx
+++ b/src/components/widget-player-page.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect} from 'react'
 import Header from './header'
 import WidgetPlayer from './widget-player'
 import useCreatePlaySession from './hooks/useCreatePlaySession'
+import { waitForWindow } from '../util/wait-for-window'
 
 const EMBED = 'embed'
 const PLAY = 'play'
@@ -40,7 +41,7 @@ const WidgetPlayerPage = () => {
 	useEffect(() => {
 		if (type == EMBED || type == PREVIEW_EMBED || type == LEGACY_EMBED) document.body.classList.add('embedded')
 
-		waitForWindow()
+		waitForWindow(['WIDGET_HEIGHT', 'WIDGET_WIDTH', 'PLAY_ID', 'DEMO_ID'])
 		.then(() => {
 			switch(type) {
 				case PREVIEW_EMBED:
@@ -93,16 +94,6 @@ const WidgetPlayerPage = () => {
 			history.pushState(null, '', `${window.location.pathname}?token=${state.ltiToken}`)
 		}
 	},[state.ltiToken])
-
-	// Used to wait for window data to load
-	const waitForWindow = async () => {
-		while(!!window.hasOwnProperty('WIDGET_HEIGHT')
-		&& !window.hasOwnProperty('WIDGET_WIDTH')
-		&& !window.hasOwnProperty('PLAY_ID')
-		&& !window.hasOwnProperty('DEMO_ID')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
 
 	let headerRender = <Header />
 	// No header for embedded widgets

--- a/src/components/widget-summary.jsx
+++ b/src/components/widget-summary.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect} from 'react'
 import { iconUrl } from '../util/icon-url'
+import { waitForWindow } from '../util/wait-for-window'
 
 const Summary = () => {
 
@@ -8,19 +9,12 @@ const Summary = () => {
 	const [avail, setAvail] = useState(null)
 
 	useEffect(() => {
-		waitForWindow().then(() => {
+		waitForWindow(['NAME', 'ICON_DIR']).then(() => {
 			setName(window.NAME)
 			setIcon(iconUrl(`${window.ICON_DIR}`,'',92))
 			setAvail(window.AVAIL)
 		})
 	})
-
-	const waitForWindow = async () => {
-		while(!window.hasOwnProperty('NAME')
-		&& !window.hasOwnProperty('ICON_DIR')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
 
 	let bodyRender = null
 	if (!!name) {

--- a/src/util/wait-for-window.js
+++ b/src/util/wait-for-window.js
@@ -1,0 +1,23 @@
+export const waitForWindow = async (properties) => {
+	const checkProperties = (properties) => {
+		return properties.every(prop => window.hasOwnProperty(prop))
+	}
+	
+	return new Promise((resolve) => {
+		if (checkProperties(properties)) {
+			resolve()
+			return
+		}
+		
+		const maxAttempts = 20
+		let attempts = 0
+		
+		const interval = setInterval(() => {
+			if (checkProperties(properties) || attempts >= maxAttempts) {
+				clearInterval(interval)
+				resolve()
+			}
+			attempts++
+		}, 500)
+	})
+}


### PR DESCRIPTION
Instead of multiple instantiations of `waitForWindow` in each component that needs it, adds a dedicated util method with better error handling. As a byproduct, fixes several instances where window object presence checks used `&&` instead of `||`, which caused unintended behavior.