### PR TITLE
Fixes user icon not reflecting user's icon preference in settings

### DIFF
--- a/app/core/services/user_service.py
+++ b/app/core/services/user_service.py
@@ -9,7 +9,7 @@ class UserService:
     @staticmethod
     def get_avatar_url(user: User) -> str:
         profile_settings = user.profile_settings
-        use_gravatar = profile_settings.get_profile_fields().get("useGravatar")
+        use_gravatar = profile_settings.get_profile_fields().get("useGravatar", False)
         if not use_gravatar:
             return f"{settings.STATIC_URL}img/default-avatar.jpg"
 

--- a/app/core/services/user_service.py
+++ b/app/core/services/user_service.py
@@ -1,5 +1,6 @@
 import hashlib
 
+from django.conf import settings
 from django.contrib.auth.models import User
 
 
@@ -7,6 +8,11 @@ class UserService:
 
     @staticmethod
     def get_avatar_url(user: User) -> str:
+        profile_settings = user.profile_settings
+        use_gravatar = profile_settings.get_profile_fields().get("useGravatar")
+        if not use_gravatar:
+            return f"{settings.STATIC_URL}img/default-avatar.jpg"
+
         clean_email = user.email.strip().lower().encode("utf-8")
         hash_email = hashlib.md5(clean_email).hexdigest()
         return f"https://www.gravatar.com/avatar/{hash_email}?d=retro&s=256"


### PR DESCRIPTION
This PR closes issue #125 

To do this, I retrieve the `useGravatar` value and conditionally render the default icon or gravatar image.


## Testing
- I tried toggling between None and use Gravatar on the settings page and ensured that both the icon on the top right and in the modal are updated accordingly
- I tried going to different pages and ensured that the icon on the top right is the same as the user icon's preference