### PR TITLE
Fix Azure AI Generation

### DIFF
--- a/app/core/services/generator_service.py
+++ b/app/core/services/generator_service.py
@@ -4,7 +4,7 @@ from datetime import datetime
 
 from core.models import Widget, WidgetInstance
 from django.conf import settings
-from openai import NOT_GIVEN, AzureOpenAI, OpenAI, OpenAIError
+from openai import NOT_GIVEN, OpenAI, OpenAIError
 from openai.types.chat import ChatCompletion
 from core.message_exception import (
     MsgInvalidInput,
@@ -297,20 +297,18 @@ class GenerationUtil:
         if settings.AI_GENERATION["PROVIDER"] == "azure_openai":
             api_key = settings.AI_GENERATION["API_KEY"]
             endpoint = settings.AI_GENERATION["ENDPOINT"]
-            api_version = settings.AI_GENERATION["API_VERSION"]
             model = settings.AI_GENERATION["MODEL"]
 
-            if not api_key or not endpoint or not api_version or not model:
+            if not api_key or not endpoint or not model:
                 logger.error(
                     "GENERATION ERROR: Azure OpenAI question generation configs missing."
                 )
                 return None
 
             try:
-                client = AzureOpenAI(
+                client = OpenAI(
                     api_key=api_key,
-                    api_version=api_version,
-                    azure_endpoint=endpoint,
+                    base_url=endpoint + "openai/v1",
                 )
             except Exception as e:
                 logger.error(

--- a/app/materia/settings/generation.py
+++ b/app/materia/settings/generation.py
@@ -10,7 +10,6 @@ AI_GENERATION = {
     "PROVIDER": os.environ.get("GENERATION_API_PROVIDER"),
     "ENDPOINT": os.environ.get("GENERATION_API_ENDPOINT"),
     "API_KEY": os.environ.get("GENERATION_API_KEY"),
-    "API_VERSION": os.environ.get("GENERATION_API_VERSION"),
     "MODEL": os.environ.get("GENERATION_API_MODEL"),
     "LOG_STATS": ValidatorUtil.validate_bool(
         os.environ.get("GENERATION_LOG_STATS"), False

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -19,7 +19,7 @@ ENABLE_ADMIN_UPLOADER=true
 
 # Session storage/cache driver
 # ALLOWED VALUES: db | file | redis
-SESSION_DRIVER=file 
+SESSION_DRIVER=file
 
 # Asset Storage Driver
 # ALLOWED VALUES: file | s3 | db
@@ -94,8 +94,8 @@ GENERATION_ALLOW_IMAGES=false
 GENERATION_API_PROVIDER=
 
 GENERATION_API_KEY=
+# If using Azure, use the base URL for your resource, trailing slash included.
 GENERATION_API_ENDPOINT=
-GENERATION_API_VERSION=
 GENERATION_API_MODEL=
 # ALLOWED VALUES: true | false
 GENERATION_LOG_STATS=false


### PR DESCRIPTION
Some env vars were lost and we can not figure out what was being used exactly to enable AI generation via Azure to work... But, either way, it seems like there is a new, slightly simpler way of using the API that OpenAI and Azure now support, and docs for the old method seem to have been replaced with the new one.

This PR switches our Azure OpenAI implementation to that method. The important changes are:
- `GENERATION_API_ENDPOINT` should now be the base URL for the Azure resource
- `GENERATION_API_VERSION` is no longer used and can be removed from the .env