### PR TITLE
Fix demo/guest plays, login bug, instance settings

### DIFF
--- a/app/core/services/widget_play_services.py
+++ b/app/core/services/widget_play_services.py
@@ -90,7 +90,7 @@ class WidgetPlayValidationService:
     def validate_widget_context(
         request,
         instance,
-        is_demo=False,
+        has_guest_access=False,
         is_preview=False,
         is_embedded=False,
         context_id=None,
@@ -108,7 +108,7 @@ class WidgetPlayValidationService:
         if not instance_availability["is_open"]:
             return WidgetPlayValidationService.INVALID_NOT_YET_OPEN
 
-        if not is_demo:
+        if not has_guest_access:
             if not instance.user_has_attempts(request.user, context_id):
                 return WidgetPlayValidationService.INVALID_NO_ATTEMPTS
 

--- a/app/core/views/login.py
+++ b/app/core/views/login.py
@@ -10,7 +10,7 @@ from django.shortcuts import redirect, render
 def login(request):
     # allow for custom authentication backend usage to launch from the regular /login route
     custom_auth_redirect = os.environ.get("AUTH_LOGIN_ROUTE_OVERRIDE", False)
-    if custom_auth_redirect:
+    if custom_auth_redirect and custom_auth_redirect.lower() != "false":
         # also allow for explicitly bypassing the custom authentication backend
         if "directlogin" in request.GET:
             # do nothing, proceed with regular login handling

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -78,7 +78,7 @@ class WidgetDemoView(MateriaLoginMixin, MateriaWidgetPlayProcessor, TemplateView
         validation = WidgetPlayValidationService.validate_widget_context(
             request,
             instance,
-            is_demo=True,
+            has_guest_access=True,
             is_preview=False,
             is_embedded=False,
         )
@@ -87,7 +87,7 @@ class WidgetDemoView(MateriaLoginMixin, MateriaWidgetPlayProcessor, TemplateView
 
     def process_context(self, validation):
         return _create_player_context(
-            validation, self.instance, self.request, is_demo=True, is_preview=False
+            validation, self.instance, self.request, is_preview=False
         )
 
     def before_play_init(self, instance):
@@ -109,10 +109,13 @@ class WidgetPlayView(
         if self.launch is not None:
             context_id = LTILaunchService.get_context_id(self.launch)
 
+        # Check if this instance is a guest/demo instance
+        has_guest_access = instance.guest_access
+
         validation = WidgetPlayValidationService.validate_widget_context(
             request,
             instance,
-            is_demo=False,
+            has_guest_access=has_guest_access,
             is_preview=False,
             is_embedded=self.is_embedded,
             context_id=context_id,
@@ -122,7 +125,7 @@ class WidgetPlayView(
 
     def process_context(self, validation):
         return _create_player_context(
-            validation, self.instance, self.request, is_demo=False, is_preview=False
+            validation, self.instance, self.request, is_preview=False
         )
 
     def before_play_init(self, instance):
@@ -193,14 +196,18 @@ class WidgetPreviewView(MateriaLoginMixin, MateriaWidgetPlayProcessor, TemplateV
 
     def get_validation(self, request, instance):
         validation = WidgetPlayValidationService.validate_widget_context(
-            request, instance, is_demo=False, is_preview=True, is_embedded=False
+            request,
+            instance,
+            has_guest_access=False,
+            is_preview=True,
+            is_embedded=False,
         )
 
         return validation
 
     def process_context(self, validation):
         return _create_player_context(
-            validation, self.instance, self.request, is_demo=False, is_preview=True
+            validation, self.instance, self.request, is_preview=True
         )
 
     def before_play_init(self, instance):
@@ -310,7 +317,6 @@ def _create_player_context(
     validation: str,
     instance: WidgetInstance,
     request: HttpRequest,
-    is_demo: bool = False,
     is_preview: bool = False,
     is_embedded: bool = False,
 ):

--- a/src/components/my-widgets-page.jsx
+++ b/src/components/my-widgets-page.jsx
@@ -103,7 +103,7 @@ const MyWidgetsPage = () => {
 
 	// checks whether "-collab" is contained in hash id
 	const hashContainsCollab = () => {
-		const match = window.location.hash.match(/#(?:[A-Za-z0-9]{5})(-collab)*$/)
+		const match = window.location.hash.match(/#(?:[A-Za-z0-9]{5,})(-collab)*$/)
 
 		if (match != null && match[1] != null)
 		{

--- a/src/components/my-widgets-settings-dialog.jsx
+++ b/src/components/my-widgets-settings-dialog.jsx
@@ -249,7 +249,7 @@ const MyWidgetsSettingsDialog = ({ onClose, inst, currentUser, otherUserPerms, o
 		// Submits the form if there are no errors
 		if (errMsg.length === 0) {
 			let args = {
-				instId: form.inst_id,
+				id: form.inst_id,
 				openAt: form.open_at,
 				closeAt: form.close_at,
 				attempts: form.attempts,


### PR DESCRIPTION
This PR fixes a handful of small bugs I've found in QA:
- At some point, saving an instance's settings broke, due to a malformed URL caused by an incorrect dictionary key. Fixed.
- Instances that have guest mode enabled did not work in most cases
  - Demos launched via the `/demo` endpoint worked, but do not work when accessed directly via the instance ID (such as occurs when pressing 'Play Again' on the score screen of a demo)
  - Instances that have guest mode enabled did not work at all
  - Was due to us passing `is_demo=False` into the `WidgetPlayValidationService` on non-demo views. I changed the param to `has_guest_access` to be a bit more clear, and added a check to the widget play views to see if the instance has guest access enabled.
- Setting `AUTH_LOGIN_ROUTE_OVERRIDE` to false (as it is by default in the env_template) did not work as intended - it was treated as `"false"` instead of `False`, causing it to be truthy. Caused a strange bug where the backend tried redirecting the user to `"false"` when a widget asked you to log in.
  - Fixed by adding a manual check to see if it is set to false. Using `validate_boolean` doesn't really work in this case since `AUTH_LOGIN_ROUTE_OVERRIDE` could be `false`, or an actual string value.
- There was one missed over area that was still checking for 5-char inst IDs. Fixed to to support 5+

There is also some minor cleanup (removal of an unused `is_demo` parameter from the `_create_player_context` function)