### PR TITLE
Allow LTI play session updates to conclude without AGS interactions.

### DIFF
--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -2,28 +2,29 @@ import logging
 import traceback
 
 from api.filters import LogPlayFilterBackend
-from core.models import Log, LogPlay, WidgetInstance
+from api.paginators import PageNumberWithTotalPagination
 from api.permissions import PlaySessionInstancePermissions
 from api.serializers import (
     PlayLogUpdateSerializer,
     PlaySessionCreateSerializer,
     PlaySessionSerializer,
 )
+from core.message_exception import MsgFailure, MsgInvalidInput
+from core.models import Log, LogPlay, WidgetInstance
+from core.services.perm_service import PermService
 from core.services.widget_play_services import WidgetPlayInitService
+from core.utils.validator_util import ValidatorUtil
 from django.conf import settings
 from django.db.models import Max
 from django.http import JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from lti.ags.client import AGSClient
+from lti.ags.exceptions.ags_claim_not_defined import AGSClaimNotDefined
 from lti.services.launch import LTILaunchService
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from scoring.module_factory import ScoreModuleFactory
-from api.paginators import PageNumberWithTotalPagination
-from core.message_exception import MsgInvalidInput, MsgFailure
-from core.services.perm_service import PermService
-from core.utils.validator_util import ValidatorUtil
 
 logger = logging.getLogger("django")
 
@@ -243,21 +244,25 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
 
                                 score_url = f"{settings.URLS["BASE_URL"]}scores/single/{play.instance.id}/{play.id}"
 
-                                ags = AGSClient(launch)
-                                completion = (
-                                    ags.score_builder()
-                                    .score_given(max_score)
-                                    .score_maximum(100)
-                                    .activity_progress("Completed")
-                                    .grading_progress("FullyGraded")
-                                    .timestamp(completed_time)
-                                    .submission_url(score_url)
-                                    .submit()
-                                )
+                                try:
+                                    ags = AGSClient(launch)
+                                    completion = (
+                                        ags.score_builder()
+                                        .score_given(max_score)
+                                        .score_maximum(100)
+                                        .activity_progress("Completed")
+                                        .grading_progress("FullyGraded")
+                                        .timestamp(completed_time)
+                                        .submission_url(score_url)
+                                        .submit()
+                                    )
 
-                                # TODO we should really have some kind of message provided to users
-                                # when LTI completion is successful
-                                logger.error(f"\ncompletion!\n{completion}\n")
+                                    # TODO we should really have some kind of message provided to users
+                                    # when LTI completion is successful
+                                    logger.error(f"\ncompletion!\n{completion}\n")
+                                except AGSClaimNotDefined:
+                                    # no AGS claim defined in the launch data, proceed as normal
+                                    pass
 
                             else:
                                 logger.error(

--- a/app/lti/ags/client.py
+++ b/app/lti/ags/client.py
@@ -3,6 +3,7 @@ from datetime import datetime
 
 from lti.services.launch import LTILaunchService
 
+from .exceptions.ags_claim_not_defined import AGSClaimNotDefined
 from .oauth import AGSOauth
 from .request import AGSRequest
 from .score_builder import AGSScoreBuilder
@@ -21,6 +22,12 @@ class AGSClient:
 
     def __init__(self, launch_data):
         self.launch_data = launch_data
+
+        # raise an exception if an AGS claim was not defined in the launch data
+        if not launch_data.get(
+            "https://purl.imsglobal.org/spec/lti-ags/claim/endpoint"
+        ):
+            raise AGSClaimNotDefined()
 
         registration = LTILaunchService.get_registration(self.launch_data)
 

--- a/app/lti/ags/exceptions/ags_claim_not_defined.py
+++ b/app/lti/ags/exceptions/ags_claim_not_defined.py
@@ -1,0 +1,5 @@
+class AGSClaimNotDefined(Exception):
+    """An AGS claim does not exist"""
+
+    def __init__(self, message="An AGS claim was not defined."):
+        super().__init__(message)


### PR DESCRIPTION
Closes #148.

Creates a new AGSClaimNotDefined exception and raises it when attempting to instantiate the AGS client without a claim being defined.