### PR TITLE
Configurable JS and CSS Base URLs

### DIFF
--- a/app/core/templates/react.html
+++ b/app/core/templates/react.html
@@ -27,7 +27,6 @@
 				<link rel="stylesheet" type="text/css" href="{% static css %}">
 			{% endfor %}
 		{% endif %}
-		<link rel="stylesheet" type="text/css" href="{% static 'dist/css/commons.css' %}" />
 
 	</head>
 	<body class="{{ page_type|default:'' }} {% if darkMode %}darkMode{% endif %}">
@@ -39,7 +38,6 @@
 				<script type="text/javascript" src="{% static js %}"></script>
 			{% endfor %}
 		{% endif %}
-		<script type="text/javascript" src="{% static 'dist/js/commons.js' %}"></script>
 		{% if js_global_variables %}
 			<script>
 				{% for key, value in js_global_variables.items %}

--- a/app/core/utils/context_util.py
+++ b/app/core/utils/context_util.py
@@ -27,6 +27,10 @@ class ContextUtil:
             [css_resources] if type(css_resources) is str else css_resources
         )
 
+        # prepend commons files to js/css resources, which are required in every page
+        processed_js_resources.insert(0, settings.JS_BASEURL + "commons.js")
+        processed_css_resources.insert(0, settings.CSS_BASEURL + "commons.css")
+
         # Create and return context
         return {
             "title": title,

--- a/app/core/views/main.py
+++ b/app/core/views/main.py
@@ -1,8 +1,9 @@
 import logging
-from django.http import HttpResponseNotFound
-from django.conf import settings
-from django.shortcuts import render
+
 from core.utils.context_util import ContextUtil
+from django.conf import settings
+from django.http import HttpResponseNotFound
+from django.shortcuts import render
 
 
 def index(request, *args, **kwargs):
@@ -35,8 +36,8 @@ def handler404(request, exception):
 
     context = ContextUtil.create(
         title="404 Page Not Found",
-        js_resources="dist/js/404.js",
-        css_resources="dist/css/404.css",
+        js_resources=settings.JS_GROUPS["404"],
+        css_resources=settings.CSS_GROUPS["404"],
         request=request,
     )
 

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -264,8 +264,8 @@ class WidgetGuideView(TemplateView):
 
         return ContextUtil.create(
             title=title,
-            js_resources="dist/js/guides.js",
-            css_resources="dist/css/guides.css",
+            js_resources=settings.JS_GROUPS["guides"],
+            css_resources=settings.CSS_GROUPS["guides"],
             page_type="guide",
             js_globals={
                 "NAME": widget.name,
@@ -290,8 +290,8 @@ class WidgetQsetHistoryView(MateriaLoginMixin, TemplateView):
         return ContextUtil.create(
             title="Qset Catalog",
             page_type="import",
-            js_resources="dist/js/qset-history.js",
-            css_resources="dist/css/qset-history.css",
+            js_resources=settings.JS_GROUPS["qset-history"],
+            css_resources=settings.CSS_GROUPS["qset-history"],
             request=self.request,
         )
 
@@ -303,8 +303,8 @@ class WidgetQsetGenerateView(MateriaLoginMixin, TemplateView):
         return ContextUtil.create(
             title="Qset Generation",
             page_type="generate",
-            js_resources="dist/js/qset-generator.js",
-            css_resources="dist/css/qset-generator.css",
+            js_resources=settings.JS_GROUPS["qset-generator"],
+            css_resources=settings.CSS_GROUPS["qset-generator"],
             request=self.request,
         )
 
@@ -379,8 +379,8 @@ def _display_widget(
 def _create_editor_page(title: str, widget: Widget, request: HttpRequest):
     return ContextUtil.create(
         title=f"{title}",
-        js_resources="dist/js/creator-page.js",
-        css_resources="dist/css/creator-page.css",
+        js_resources=settings.JS_GROUPS["creator"],
+        css_resources=settings.CSS_GROUPS["creator"],
         js_globals={
             "WIDGET_HEIGHT": widget.height,
             "WIDGET_WIDTH": widget.width,

--- a/app/materia/settings/base.py
+++ b/app/materia/settings/base.py
@@ -41,6 +41,7 @@ SESSION_COOKIE_SAMESITE = "None"
 SESSION_COOKIE_SECURE = True
 CSRF_COOKIE_SAMESITE = "None"
 CSRF_COOKIE_SECURE = True
+CSRF_TRUSTED_ORIGINS = [os.environ.get("BASE_URL").rstrip("/")]
 
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/

--- a/app/materia/settings/css.py
+++ b/app/materia/settings/css.py
@@ -1,6 +1,8 @@
+import os
+
 # CSS group definition configs
 
-CSS_BASEURL = "dist/css/"
+CSS_BASEURL = os.environ.get("CSS_BASEURL", "dist/css/")
 FONTS_BASEURL = "https://fonts.googleapis.com/"
 
 FONTS_DEFAULT = [
@@ -16,6 +18,7 @@ CSS_GROUPS = {
     "catalog": [CSS_BASEURL + "catalog.css"],
     "detail": [CSS_BASEURL + "detail.css"],
     "player": [CSS_BASEURL + "player-page.css"],
+    "creator": [CSS_BASEURL + "creator-page.css"],
     "login": [CSS_BASEURL + "login.css"],
     "profile": [CSS_BASEURL + "profile.css"],
     "settings": [CSS_BASEURL + "settings.css"],
@@ -30,4 +33,8 @@ CSS_GROUPS = {
         CSS_BASEURL + "lti-select-item.css",
         CSS_BASEURL + "lti-error.css",
     ],
+    "404": [CSS_BASEURL + "404.css"],
+    "guides": [CSS_BASEURL + "guides.css"],
+    "qset-history": [CSS_BASEURL + "qset-history.css"],
+    "qset-generator": [CSS_BASEURL + "qset-generator.css"],
 }

--- a/app/materia/settings/js.py
+++ b/app/materia/settings/js.py
@@ -1,6 +1,8 @@
+import os
+
 # JS group definition configs
 
-JS_BASEURL = "dist/js/"
+JS_BASEURL = os.environ.get("JS_BASEURL", "dist/js/")
 
 JS_GROUPS = {
     "main": [JS_BASEURL + "homepage.js"],
@@ -9,6 +11,7 @@ JS_GROUPS = {
     "catalog": [JS_BASEURL + "catalog.js"],
     "detail": [JS_BASEURL + "detail.js"],
     "player": [JS_BASEURL + "player-page.js"],
+    "creator": [JS_BASEURL + "creator-page.js"],
     "login": [JS_BASEURL + "login.js"],
     "closed": [JS_BASEURL + "closed.js"],
     "draft-not-playable": [JS_BASEURL + "draft-not-playable.js"],
@@ -28,4 +31,8 @@ JS_GROUPS = {
     "select-item": [JS_BASEURL + "lti-select-item.js"],
     "open-preview": [JS_BASEURL + "lti-open-preview.js"],
     "lti-error": [JS_BASEURL + "lti-error.js"],
+    "404": [JS_BASEURL + "404.js"],
+    "guides": [JS_BASEURL + "guides.js"],
+    "qset-history": [JS_BASEURL + "qset-history.js"],
+    "qset-generator": [JS_BASEURL + "qset-generator.js"],
 }

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -26,6 +26,13 @@ SESSION_DRIVER=file
 ASSET_STORAGE_DRIVER=file
 
 # ==========================================================
+# OPTIONAL SETTINGS
+# ==========================================================
+# Override these if your static files aren't in ./staticfiles/dist/
+# JS_BASEURL=
+# CSS_BASEURL=
+
+# ==========================================================
 # CONDITIONALLY MANDATORY SETTINGS
 # ==========================================================
 # These settings are required depending driver selection.


### PR DESCRIPTION
Resolves #152 

Adds optional `JS_BASEURL` and `CSS_BASEURL` environment variables that are loaded by their respective configs. Defaults to `dist/js/` and `dist/css/` if they are not present.

Adds missing `JS_GROUPS` and `CSS_GROUPS` and updates static refs in various views to point to them instead.

Adds default `CSRF_TRUSTED_ORIGINS` setting to `base.py`, which defaults to the `BASE_URL` environment config.