### PR TITLE
NGINX tweaks

### DIFF
--- a/docker/config/nginx/sites-enabled/site.conf
+++ b/docker/config/nginx/sites-enabled/site.conf
@@ -13,26 +13,26 @@ server {
 	}
 
 	location @handler {
-			proxy_pass http://python:8001;
+		proxy_pass http://python:8001;
 
-			proxy_set_header Host $host;
-			proxy_set_header X-Real-IP $remote_addr;
-			proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-			proxy_set_header X-Forwarded-Proto $scheme;
+		proxy_set_header Host $host;
+		proxy_set_header X-Real-IP $remote_addr;
+		proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+		proxy_set_header X-Forwarded-Proto $scheme;
 
-			proxy_read_timeout    300;
-			proxy_send_timeout    300;
-			proxy_connect_timeout 300;
+		proxy_read_timeout    300;
+		proxy_send_timeout    300;
+		proxy_connect_timeout 300;
 
-			proxy_redirect off;
+		proxy_redirect off;
 	}
 
-    # Automatically check to see if an image theme override exists, then fall back to default
-    location ~/static/img/(.*)$ {
-        try_files /theme/img/$1 /img/$1;
-        autoindex on;
-        # expires 1d;
-    }
+	# Automatically check to see if an image theme override exists, then fall back to default
+	location ~/static/img/(.*)$ {
+		try_files /theme/img/$1 /img/$1;
+		autoindex on;
+		# expires 1d;
+	}
 
 	location /static {
 		alias /var/www/html/staticfiles;
@@ -40,16 +40,14 @@ server {
 		# expires 1d;
 	}
 
-    # Temp? rule to prevent django's 404 page from appearing on static assets
-    # Firefox freaks out when its expecting a .js file and it gets a django's html instead
-	location /widget/ {
-	    try_files $uri =404;
+	location /js {
+		alias /var/www/html/staticfiles/js;
+		autoindex on;
 	}
 
-	# In the dev environment, js and css assets are emitted to public/dist instead of public/
-    # However, server pages will expect them to be in public/js or public/css instead
-    # Redirect requests for these assets to public/dist
-    location ~* ^\/(?:js|css)\/.+\.(?:js|css)$ {
-        proxy_pass http://$server_addr/dist$uri;
-    }
+	# Temp? rule to prevent django's 404 page from appearing on static assets
+	# Firefox freaks out when its expecting a .js file and it gets a django's html instead
+	location /widget/ {
+		try_files $uri =404;
+	}
 }


### PR DESCRIPTION
On QA, changes to the NGINX config meant widgets couldn't find the `-core` files at `/js/materia.creatorcore.js`, `/js/materia.enginecore.js`, and so on. Adds an alias for `/js` requests to point to `/static/js` instead.

Also cleans up the proxy_pass directive to redirect to `dist/`, and standardizes indentation.