### PR TITLE
Various scoring fixes

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -5,8 +5,6 @@ import json
 import logging
 import os
 
-from django.conf import settings
-
 from core.models import (
     Asset,
     DateRange,
@@ -25,6 +23,7 @@ from core.services.perm_service import PermService
 from core.services.semester_service import SemesterService
 from core.services.user_service import UserService
 from core.utils.b64_util import Base64Util
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 from rest_framework import serializers
@@ -570,6 +569,7 @@ class ScoreSummarySerializer(serializers.Serializer):
             return []
 
         summary = {}
+        unique_students = {}
 
         for log in logs:
 
@@ -586,6 +586,8 @@ class ScoreSummarySerializer(serializers.Serializer):
                     else:
                         distribution[i] = 0
 
+                unique_students[semester_key] = [log.user.id]
+
                 summary[semester_key] = {
                     "id": log.semester.id,
                     "term": log.semester.semester,
@@ -596,9 +598,12 @@ class ScoreSummarySerializer(serializers.Serializer):
                 }
 
             else:
-                summary[semester_key]["students"] += 1
-                summary[semester_key]["total"] += log.percent
 
+                if log.user.id not in unique_students[semester_key]:
+                    unique_students[semester_key].append(log.user.id)
+                    summary[semester_key]["students"] += 1
+
+                summary[semester_key]["total"] += log.percent
                 summary[semester_key]["distribution"][
                     int(log.percent / 10) if int(log.percent / 10) < 10 else 9
                 ] += 1

--- a/app/api/views/scores.py
+++ b/app/api/views/scores.py
@@ -1,19 +1,19 @@
 import logging
 
-from core.models import LogPlay, WidgetInstance
 from api.serializers import (
     QuestionSetSerializer,
     ScoreDetailsForPlaySerializer,
     ScoreDetailsForPreviewSerializer,
     ScoresForUserSerializer,
 )
+from core.message_exception import MsgExpired, MsgNoPerm
+from core.models import LogPlay, WidgetInstance
+from core.services.perm_service import PermService
+from core.services.semester_service import SemesterService
 from rest_framework.permissions import AllowAny, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from scoring.module_factory import ScoreModuleFactory
-from core.message_exception import MsgNoPerm, MsgExpired
-from core.services.perm_service import PermService
-from core.services.semester_service import SemesterService
 
 logger = logging.getLogger(__name__)
 
@@ -63,11 +63,7 @@ class ScoresView(APIView):
                 user=user, instance=instance, is_complete=True
             )
 
-            if validated.get("context"):
-                plays = plays.filter(context_id=context)
-            else:
-                semester = SemesterService.get_current_semester()
-                plays = plays.filter(semester=semester)
+            semester = SemesterService.get_current_semester()
 
             scores = []
             for play in plays.order_by("-created_at"):
@@ -82,6 +78,7 @@ class ScoresView(APIView):
                         "id": play.id,
                         "created_at": play.created_at.isoformat(),
                         "percent": details.get("overview", {}).get("score", 0),
+                        "current_semester": play.semester == semester,
                     }
                 )
 

--- a/app/api/views/scores.py
+++ b/app/api/views/scores.py
@@ -73,12 +73,16 @@ class ScoresView(APIView):
 
                 details = module.get_score_report()
 
+                current_context = (
+                    play.context_id == context and play.semester == semester
+                )
+
                 scores.append(
                     {
                         "id": play.id,
                         "created_at": play.created_at.isoformat(),
                         "percent": details.get("overview", {}).get("score", 0),
-                        "current_semester": play.semester == semester,
+                        "current_context": current_context,
                     }
                 )
 

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -304,7 +304,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
 
         logs_for_user = (
-            LogPlay.objects.filter(instance=instance)
+            LogPlay.objects.filter(instance=instance, is_complete=True)
             .order_by("-created_at", "semester")
             .select_related("semester")
         )

--- a/app/core/views/scores.py
+++ b/app/core/views/scores.py
@@ -1,5 +1,8 @@
+import logging
+
 from core.mixins import MateriaLoginMixin, MateriaLoginNeeded
 from core.models import LogPlay, WidgetInstance
+from core.utils.context_util import ContextUtil
 from django.conf import settings
 from django.http import (
     Http404,
@@ -9,7 +12,8 @@ from django.http import (
 )
 from django.views.generic import TemplateView
 from lti.services.launch import LTILaunchService
-from core.utils.context_util import ContextUtil
+
+logger = logging.getLogger(__name__)
 
 
 class ScoresView(MateriaLoginMixin, TemplateView):
@@ -18,29 +22,21 @@ class ScoresView(MateriaLoginMixin, TemplateView):
 
     def get(self, request, *args, **kwargs):
         widget_instance_id = kwargs.get("widget_instance_id")
+        token = request.GET.get("token")
 
         instance = WidgetInstance.objects.filter(pk=widget_instance_id).first()
         if not instance:
             return HttpResponseNotFound()
+        context = _get_context_data(request, widget_instance_id, token)
 
         if not instance.playable_by_current_user(self.request.user):
-            return ContextUtil.create(
+            context = ContextUtil.create(
                 request=request,
                 title="Forbidden",
                 js_resources=settings.JS_GROUPS["no-permission"],
                 css_resources=settings.CSS_GROUPS["no-permission"],
                 js_globals={},
             )
-
-        context = ContextUtil.create(
-            title="Score Results",
-            js_resources=settings.JS_GROUPS["scores"],
-            css_resources=settings.CSS_GROUPS["scores"],
-            js_globals={
-                "USER_ID": request.user.id,
-            },
-            request=self.request,
-        )
 
         return self.render_to_response(context)
 
@@ -56,7 +52,7 @@ class ScoresViewSingle(MateriaLoginMixin, TemplateView):
         # Get url args
         play_id = kwargs.get("play_id")
         widget_instance_id = kwargs.get("widget_instance_id")
-        token = self.kwargs.get("token")  # TODO verify if token is visible here
+        token = request.GET.get("token")
 
         # Grab and verify play
         play = LogPlay.objects.get(pk=play_id)
@@ -64,17 +60,6 @@ class ScoresViewSingle(MateriaLoginMixin, TemplateView):
             return HttpResponseNotFound()
         if play.instance.id != widget_instance_id:
             return HttpResponseBadRequest()
-
-        # TODO
-        # Revisit this redirect: this event trigger was associated LTI 1.1
-
-        # Allow event listeners to redirect users
-        # This is mostly to redirect them to failure status pages
-        # $results = \Event::trigger('before_single_score_review',
-        # ['play_id' => $play_id, 'content_id' => $play->context_id], 'array');
-
-        # if redirect:
-        #     return HttpResponseRedirect(redirect)
 
         context = _get_context_data(request, widget_instance_id, token)
         return self.render_to_response(context)
@@ -94,16 +79,20 @@ def _get_context_data(
     if not instance.playable_by_current_user(request.user):
         raise MateriaLoginNeeded(login_message="Please log in to view your scores.")
 
-    # Set up context and return
+    # configure JS globals, USER_ID is always required
     js_globals = {
         "USER_ID": request.user.id,
     }
 
+    # if there is a token param present, append additional globals to communicate LTI context
     if token:
         js_globals["LTI_TOKEN"] = token
-
-    if LTILaunchService.is_lti_launch(request):
-        js_globals["LTI_EMBEDDED"] = True
+        launch = LTILaunchService.get_session_launch(request, token)
+        if launch:
+            js_globals["CONTEXT_ID"] = LTILaunchService.get_context_id(launch)
+    else:
+        if LTILaunchService.is_lti_launch(request):
+            js_globals["LTI_EMBEDDED"] = True
 
     return ContextUtil.create(
         title="Score Results",

--- a/app/lti/views/lti.py
+++ b/app/lti/views/lti.py
@@ -5,10 +5,7 @@ from django.conf import settings as django_settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
 
-# from lti.ags.client import AGSClient
-from lti.services.launch import LTILaunchService
-
-# from pprint import pformat
+# from lti.services.launch import LTILaunchService
 
 
 logger = logging.getLogger("django")
@@ -17,19 +14,25 @@ logger = logging.getLogger("django")
 @login_required
 def post_login(request):
 
-    launch = LTILaunchService.get_or_recover_launch(request)
-    context_id = None
-
-    if launch is not None:
-        context_id = LTILaunchService.get_context_id(launch)
-        LTILaunchService.store_session_launch(request, context_id, launch)
+    # the following code is being commented out for now:
+    # passing the context ID is required for additional functionality on the post_login view
+    # associated with requesting instances available in given a course context
+    # until that feature is mature, context ID does not need to be passed to the front end
+    # nor do we need to store the launch in session
+    # =============================================
+    # launch = LTILaunchService.get_or_recover_launch(request)
+    # context_id = None
+    # if launch is not None:
+    #     context_id = LTILaunchService.get_context_id(launch)
+    #     LTILaunchService.store_session_launch(request, context_id, launch)
+    # =============================================
 
     context = ContextUtil.create(
         title="Profile",
         js_resources=django_settings.JS_GROUPS["post-login"],
         css_resources=django_settings.CSS_GROUPS["lti"],
         request=request,
-        js_globals={"CONTEXT_ID": context_id},
+        # js_globals={"CONTEXT_ID": context_id},
     )
 
     return render(request, "react.html", context)

--- a/src/components/score-page.jsx
+++ b/src/components/score-page.jsx
@@ -1,6 +1,8 @@
 import React, {useState, useEffect, useMemo} from 'react'
 import Header from './header'
 import Scores from './scores'
+import LoadingIcon from './loading-icon'
+import { waitForWindow } from '../util/wait-for-window'
 
 const ScorePage = () => {
 
@@ -35,24 +37,20 @@ const ScorePage = () => {
 	})
 
 	useEffect(() => {
-		waitForWindow()
+		waitForWindow(['USER_ID'])
 		.then(() => {
 			setState({
 				...state,
 				userID: window.USER_ID ?? null,
 				playID: playID,
-				token: token,
+				token: token ?? null,
+				contextID: window.CONTEXT_ID ?? null,
 				isEmbedded: isEmbed || !!token || !!window.LTI_EMBEDDED,
 				ready: true
 			})
 		})
 	}, [])
 
-	const waitForWindow = async () => {
-		while(!window.hasOwnProperty('USER_ID')) {
-			await new Promise(resolve => setTimeout(resolve, 500))
-		}
-	}
 
 	let headerRender = null
 	if (!state.isEmbedded) {
@@ -66,9 +64,13 @@ const ScorePage = () => {
 		playID={state.playID}
 		userID={state.userID}
 		token={state.token}
+		contextID={state.contextID}
 		isEmbedded={state.isEmbedded}
 		isPreview={state.isPreview}
 		isSingle={state.isSingle}/>
+	}
+	else {
+		bodyRender = <LoadingIcon size='med' />
 	}
 
 	if (state.isEmbedded) document.body.classList.add('embedded')

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -474,7 +474,7 @@ const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedd
 	if (!attributes.hidePreviousAttempts) {
 		let attemptList = attempts.map((attempt, index) => {
 			return (
-				<li key={index} className={ !!attempt.current_semester ? 'current-semester' : 'previous-semester' }>
+				<li key={index} className={ !!attempt.current_context ? 'current-context' : 'previous-context' }>
 					<a href={`#attempt-${index + 1}`}
 						onClick={() => setKeepPrevOpen(false)}
 					>

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -318,7 +318,6 @@ const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedd
 					showResultsTable: true
 				})
 			}
-			console.log("calling sendToWidget")
 			sendToWidget('initWidget', [playData.qset, playData.details.table, instance, isPreview, window.MEDIA_URL])
 		}
 	}
@@ -502,10 +501,8 @@ const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedd
 		)
 	}
 
-	console.log(attemptsLeft)
-
 	let playAgainBtn = null
-	if (!attributes.hidePlayAgain && attemptsLeft > 0) {
+	if (!attributes.hidePlayAgain && (attemptsLeft > 0 || attemptsLeft == -1)) {
 		playAgainBtn = (
 			<a id='play-again' className='action_button' href={attributes.href}>
 				{isPreview ? 'Preview' : 'Play'} Again

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -14,7 +14,7 @@ const STATE_INVALID = 'invalid'
 const STATE_EXPIRED = 'expired'
 const STATE_NO_SCORES = 'no_scores'
 
-const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPreview, isSingle}) => {
+const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedded, isPreview, isSingle}) => {
 
 	const [playID, setPlayID] = useState(playIDProp)
 	const [errorState, setErrorState] = useState(null)
@@ -64,9 +64,9 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 		Also disabled for guest plays, preview plays
 	*/
 	const { isLoading: scoresAreLoading, data: instanceScores, error: instanceScoresError, refetch: loadInstanceScores } = useQuery({
-		queryKey: ['inst-scores', instID],
+		queryKey: ['inst-scores', instID, contextID],
 		queryFn: () => {
-			return apiGetWidgetInstanceScores(instID, userID)
+			return apiGetWidgetInstanceScores(instID, userID, contextID)
 		},
 		enabled: !isPreview && !isSingle && !instanceIsLoading && !instance['guest_access'] && !!userID && !!instID,
 		staleTime: Infinity,
@@ -475,7 +475,7 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 	if (!attributes.hidePreviousAttempts) {
 		let attemptList = attempts.map((attempt, index) => {
 			return (
-				<li key={index}>
+				<li key={index} className={ !!attempt.current_semester ? 'current-semester' : 'previous-semester' }>
 					<a href={`#attempt-${index + 1}`}
 						onClick={() => setKeepPrevOpen(false)}
 					>
@@ -502,20 +502,23 @@ const Scores = ({ instID, playID: playIDProp, userID, token, isEmbedded, isPrevi
 		)
 	}
 
+	console.log(attemptsLeft)
+
 	let playAgainBtn = null
-	if ((!attributes.hidePlayAgain && attemptsLeft > 0) || attemptsLeft == -1) {
+	if (!attributes.hidePlayAgain && attemptsLeft > 0) {
 		playAgainBtn = (
 			<a id='play-again' className='action_button' href={attributes.href}>
 				{isPreview ? 'Preview' : 'Play'} Again
-				{attemptsLeft > 0 ? <span>({attemptsLeft} Left)</span> : <></>}
+				{attemptsLeft > 0 ? <span>{`(${attemptsLeft} Left)`}</span> : <></>}
 			</a>
 		)
 	}
 
 	let scoreHeaderRender = null
 	if (!errorState) {
+		const headerClass = playAgainBtn == null ? 'justify-left' : 'justify-center'
 		scoreHeaderRender = (
-			<header className={`header score-header ${isPreview ? 'preview' : ''}`}>
+			<header className={`header score-header ${headerClass} ${isPreview ? 'preview' : ''}`}>
 				{priorAttempts}
 				<h1 className='widget-title'>{attributes.title ? attributes.title : ''}</h1>
 				{playAgainBtn}

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -308,6 +308,11 @@ article {
 		border-top-right-radius: 5px;
 		border-bottom: 1px $light-gray-bg solid;
 
+		&.justify-left {
+			justify-content: flex-start;
+			gap: 2em;
+		}
+
 		&.preview {
 			margin-top: 65px;
 			border-top: 4px $preview-purple solid;
@@ -418,7 +423,18 @@ article {
 					padding: 0.5em 1em;
 					list-style: none;
 
-					border-radius: 15px;
+					&:first-child {
+						border-top-right-radius: 15px;
+					}
+					
+					&:last-child {
+						border-bottom-left-radius: 15px;
+						border-bottom-right-radius: 15px;
+					}
+
+					&.previous-semester {
+						background: #eee;
+					}
 
 					&:hover {
 						background-color: #d0eeff;

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -432,7 +432,7 @@ article {
 						border-bottom-right-radius: 15px;
 					}
 
-					&.previous-semester {
+					&.previous-context {
 						background: #eee;
 					}
 

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -261,10 +261,9 @@ export const apiSearchInstances = (input, pageParam = 1, include_deleted = false
 	return handleRequest(methods.GET, `/api/instances/?search=${input}&page=${pageParam}&include_deleted=${include_deleted}`)
 }
 
-// TODO update or retire
-export const apiGetWidgetInstanceScores = (instId, userId) => {
-	console.log(`inst id: ${instId}, user id: ${userId}`)
-	return handleRequest(methods.GET, `/api/scores/?inst_id=${instId}&user=${userId}`)
+export const apiGetWidgetInstanceScores = (instId, userId, contextId=null) => {
+	const url = `/api/scores/?inst_id=${instId}&user=${userId}${contextId != null ? '&context=' + contextId : ''}`
+	return handleRequest(methods.GET, url)
 }
 
 export const apiGetWidgetInstancePlayScores = (playId) => {


### PR DESCRIPTION
Resolves #157, #158, and #128.

- `/api/instances/<inst id>/performance/` only includes completed plays
- Various fixes in Scores view processing. Both `ScoresView` and `ScoresDetailView` utilize `_get_context_data`, and updated how JS globals are appended based on LTI conditions.
- `apiGetWidgetInstanceScores` now includes an optional `contextId` param that is utilized by the score screen when a `CONTEXT_ID` global is present. This allows `/api/scores/` to correctly provide the right number of remaining attempts for a given context.
- The "Prev. Attempts" drop-down now includes all play records for a given user and instance, regardless of context. Attempts within the current context are now visually distinct to attempts from other contexts and semesters.
- Fixed the display conditions of the Play Again button.
- Disabled some code in the `post_login` view that would store LTI launch information in session.
- Fixed an issue where the `ScoreSummarySerializer` was not correctly calculating unique students per semester.