### PR TITLE
LTI and LTI-adjacent fixes and polish

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -5,8 +5,6 @@ import json
 import logging
 import os
 
-from django.conf import settings
-
 from core.models import (
     Asset,
     DateRange,
@@ -25,6 +23,7 @@ from core.services.perm_service import PermService
 from core.services.semester_service import SemesterService
 from core.services.user_service import UserService
 from core.utils.b64_util import Base64Util
+from django.conf import settings
 from django.contrib.auth.models import User
 from django.db import transaction
 from rest_framework import serializers
@@ -451,29 +450,6 @@ class PlayLogUpdateSerializer(serializers.Serializer):
             raise serializers.ValidationError(
                 f"Play ID {self.context["play_id"]} invalid."
             )
-
-
-class PlaySessionCreateSerializer(serializers.Serializer):
-    instanceId = serializers.CharField()
-    is_preview = serializers.BooleanField(required=False)
-
-    def validate(self, data):
-        is_preview = data.get("is_preview", False)
-        if is_preview is True:
-            raise serializers.ValidationError(
-                "Invalid session creation for preview play."
-            )
-
-        instance = WidgetInstance.objects.get(pk=data["instanceId"])
-        if not instance:
-            raise serializers.ValidationError(
-                f"Instance ID {data["InstanceId"]} invalid."
-            )
-
-        if not instance.playable_by_current_user(self.context["request"].user):
-            raise serializers.ValidationError("Instance not playable by current user.")
-
-        return {"instance": instance, "is_preview": is_preview}
 
 
 # play session model (kinda) serializer (outbound)

--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -4,25 +4,22 @@ import traceback
 from api.filters import LogPlayFilterBackend
 from api.paginators import PageNumberWithTotalPagination
 from api.permissions import PlaySessionInstancePermissions
-from api.serializers import (
-    PlayLogUpdateSerializer,
-    PlaySessionCreateSerializer,
-    PlaySessionSerializer,
-)
+from api.serializers import PlayLogUpdateSerializer, PlaySessionSerializer
 from core.message_exception import MsgFailure, MsgInvalidInput
 from core.models import Log, LogPlay, WidgetInstance
 from core.services.perm_service import PermService
-from core.services.widget_play_services import WidgetPlayInitService
 from core.utils.validator_util import ValidatorUtil
 from django.conf import settings
 from django.db.models import Max
-from django.http import JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from lti.ags.client import AGSClient
 from lti.ags.exceptions.ags_claim_not_defined import AGSClaimNotDefined
+from lti.ags.exceptions.ags_no_line_item import AGSNoLineItem
+from lti.ags.util import AGSUtil
 from lti.services.launch import LTILaunchService
 from rest_framework import permissions, status, viewsets
 from rest_framework.decorators import action
+from rest_framework.exceptions import MethodNotAllowed
 from rest_framework.response import Response
 from scoring.module_factory import ScoreModuleFactory
 
@@ -114,41 +111,7 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
         return PlaySessionSerializer
 
     def create(self, request):
-        serializer = PlaySessionCreateSerializer(
-            data=request.data, context={"request": request}
-        )
-        if serializer.is_valid(raise_exception=True):
-            validated = serializer.validated_data
-
-            if validated["is_preview"] is True:
-
-                preview_id = WidgetPlayInitService.init_preview(request)
-                return JsonResponse({"playId": preview_id})
-
-            else:
-                user = (
-                    request.user
-                    if validated["instance"].guest_access is False
-                    else None
-                )
-
-                # disallow plays for non-playable widget engines
-                if not validated["instance"].widget.is_playable:
-                    raise MsgFailure(
-                        "Failed to Create Play Session", "This widget is not playable."
-                    )
-
-                # init the new play
-                new_play = WidgetPlayInitService.init_play(
-                    request, validated["instance"], user
-                )
-                if not new_play.id:
-                    raise MsgFailure(
-                        "Failed to Create Play Session",
-                        "There was an error starting your play session. Please try again.",
-                    )
-
-                return JsonResponse({"playId": new_play.id})
+        raise MethodNotAllowed("POST")
 
     def update(self, request, pk=None):
         if not pk:
@@ -226,7 +189,7 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                                 request, play.lti_token
                             )
 
-                            if launch:
+                            if launch and AGSUtil.is_ags_scoring_available(launch):
                                 context_history = LogPlay.objects.filter(
                                     instance=play.instance,
                                     user=play.user,
@@ -246,7 +209,7 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
 
                                 try:
                                     ags = AGSClient(launch)
-                                    completion = (
+                                    (
                                         ags.score_builder()
                                         .score_given(max_score)
                                         .score_maximum(100)
@@ -257,17 +220,37 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                                         .submit()
                                     )
 
-                                    # TODO we should really have some kind of message provided to users
-                                    # when LTI completion is successful
-                                    logger.error(f"\ncompletion!\n{completion}\n")
-                                except AGSClaimNotDefined:
-                                    # no AGS claim defined in the launch data, proceed as normal
-                                    pass
+                                    logger.error(
+                                        f"LTI-AGS: successfully transmitted "
+                                        f"completion for play {play.id}"
+                                    )
 
+                                except AGSClaimNotDefined:
+                                    logger.error(
+                                        f"LTI-AGS: AGS claim not defined "
+                                        f"for play {play.id}"
+                                    )
+                                except AGSNoLineItem:
+                                    logger.error(
+                                        f"LTI-AGS: no AGS operations performed; "
+                                        f"a line item was not provided for play {play.id}"
+                                    )
+                                except Exception as e:
+                                    logger.error(
+                                        f"LTI-AGS: failed to transmit completion "
+                                        f"for play {play.id}: {str(e)}"
+                                    )
                             else:
-                                logger.error(
-                                    "\nCould NOT recover launch from session!\n"
-                                )
+                                if launch is None:
+                                    logger.error(
+                                        f"LTI-AGS: launch recovery failure: unable to "
+                                        f"retrieve launch for play {play.id}"
+                                    )
+                                else:
+                                    logger.error(
+                                        f"LTI-AGS: no AGS operations performed; "
+                                        f"AGS scoring unavailable for play {play.id}"
+                                    )
                                 pass
                 else:
                     preview_play_id = update_serializer.validated_data[
@@ -287,13 +270,8 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                 logger.error(f"\ntraceback: {tbString}")
                 raise MsgFailure("Failed to Save", "Your play logs could not be saved.")
 
-    def destroy(self, request, *args, **kwargs):
-        return Response(
-            {
-                "detail": "This operation is not allowed.",
-                "status": status.HTTP_403_FORBIDDEN,
-            }
-        )
+    def destroy(self, request):
+        raise MethodNotAllowed("DELETE")
 
     @action(detail=True, methods=["get"])
     def verify(self, request, pk=None):

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -153,6 +153,10 @@ class WidgetPlayView(
             play.lti_token = lti_token
             play.save()
 
+            logger.error(
+                f"LTI: session initialization for user {play.user.id} with play {play.id} in context {play.context_id}"
+            )
+
         return {"play_id": play.id, "lti_token": lti_token}
 
     # overrides the baseline LTILaunchMixin's launch success method

--- a/app/lti/ags/client.py
+++ b/app/lti/ags/client.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from lti.services.launch import LTILaunchService
 
 from .exceptions.ags_claim_not_defined import AGSClaimNotDefined
+from .exceptions.ags_no_line_item import AGSNoLineItem
 from .oauth import AGSOauth
 from .request import AGSRequest
 from .score_builder import AGSScoreBuilder
@@ -64,6 +65,9 @@ class AGSClient:
         )
 
         line_item = AGSUtil.get_line_item_from_launch(self.launch_data)
+        if line_item is None:
+            raise AGSNoLineItem()
+
         url = f"{line_item}/scores"
         request = AGSRequest(self.access_token)
 

--- a/app/lti/ags/exceptions/ags_no_line_item.py
+++ b/app/lti/ags/exceptions/ags_no_line_item.py
@@ -1,0 +1,8 @@
+class AGSNoLineItem(Exception):
+    """
+    A Line Item does not exist in the AGS claim.
+    This is most often due to a launch that is not associated with a gradebook entry.
+    """
+
+    def __init__(self, message="A Line Item does not exist in the AGS claim."):
+        super().__init__(message)

--- a/app/lti/ags/request.py
+++ b/app/lti/ags/request.py
@@ -1,5 +1,4 @@
 import logging
-from pprint import pformat
 
 import requests
 
@@ -24,7 +23,6 @@ class AGSRequest:
 
         response = requests.get(url, headers=self.headers())
         body = response.json()
-        logger.error(f"\nAGSRequest GET:\n{pformat(body)}\n")
         response.raise_for_status()
 
         return body
@@ -32,7 +30,6 @@ class AGSRequest:
     def post(self, url, body):
         response = requests.post(url, json=body, headers=self.headers())
         body = response.json()
-        logger.error(f"\nAGSRequest POST:\n{pformat(body)}\n")
         response.raise_for_status()
 
         return body

--- a/app/lti/ags/util.py
+++ b/app/lti/ags/util.py
@@ -31,3 +31,13 @@ class AGSUtil:
             user_id = launch_data.get(settings.LTI_USERDATA["ags_identifier"])
 
         return int(user_id)
+
+    @staticmethod
+    def is_ags_scoring_available(launch):
+        ags_claim = launch.get("https://purl.imsglobal.org/spec/lti-ags/claim/endpoint")
+        if ags_claim:
+            scope = ags_claim.get("scope")
+            if scope and "https://purl.imsglobal.org/spec/lti-ags/scope/score" in scope:
+                return True
+
+        return False

--- a/app/lti/views/launch.py
+++ b/app/lti/views/launch.py
@@ -6,9 +6,6 @@ from lti.services.launch import LTILaunchService
 from lti.views.lti import error_page
 from lti_tool.views import LtiLaunchBaseView
 
-# from pprint import pformat
-
-
 logger = logging.getLogger("django")
 
 

--- a/app/lti/views/lti.py
+++ b/app/lti/views/lti.py
@@ -4,12 +4,7 @@ from core.utils.context_util import ContextUtil
 from django.conf import settings as django_settings
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import render
-
-# from lti.ags.client import AGSClient
 from lti.services.launch import LTILaunchService
-
-# from pprint import pformat
-
 
 logger = logging.getLogger("django")
 


### PR DESCRIPTION
- Improved error boundaries around AGS. Added `AGSNoLineItem` exception and cascading exception handlers during LTI end-of-play processing.
- Added a dedicated `is_ags_scoring_available()` util method to verify if score-related AGS claims are present in launch data.
- Added "production-ready" logging for LTI session init and resolution states.
- Removed the `create` method from play sessions API, since those operations are handled by the `MateriaWidgetPlayProcessor` mixin and the `WidgetPlayInitService`. Removed the associated play session create serializer as well.