### PR TITLE
Fixes embed conditions for pre embed

### DIFF
--- a/app/core/mixins.py
+++ b/app/core/mixins.py
@@ -2,9 +2,9 @@ import logging
 
 from core.models import WidgetInstance
 from core.services.widget_play_services import WidgetPlayValidationService
+from core.utils.context_util import ContextUtil
 from django.contrib.auth.mixins import AccessMixin
 from django.http import HttpRequest, HttpResponse
-from core.utils.context_util import ContextUtil
 
 logger = logging.getLogger("django")
 
@@ -116,7 +116,6 @@ class MateriaWidgetPlayProcessor:
         if inst_id is not None:
             self.instance = WidgetInstance.objects.filter(pk=inst_id).first()
             self.is_embedded = kwargs.get("is_embed", False)
-
             self.validation = self.get_validation(request, self.instance)
 
         return super().dispatch(request, *args, **kwargs)

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -125,7 +125,11 @@ class WidgetPlayView(
 
     def process_context(self, validation):
         return _create_player_context(
-            validation, self.instance, self.request, is_preview=False
+            validation,
+            self.instance,
+            self.request,
+            is_preview=False,
+            is_embedded=self.is_embedded,
         )
 
     def before_play_init(self, instance):
@@ -211,7 +215,11 @@ class WidgetPreviewView(MateriaLoginMixin, MateriaWidgetPlayProcessor, TemplateV
 
     def process_context(self, validation):
         return _create_player_context(
-            validation, self.instance, self.request, is_preview=True
+            validation,
+            self.instance,
+            self.request,
+            is_preview=True,
+            is_embedded=self.is_embedded,
         )
 
     def before_play_init(self, instance):
@@ -507,7 +515,6 @@ def _create_pre_embed_placeholder_page(request: HttpRequest, instance: WidgetIns
 
 
 def _create_embedded_only_page(request: HttpRequest, instance: WidgetInstance):
-    # TODO 'before_embedded_only' event trigger occurred here
 
     return ContextUtil.create(
         title="Widget Unavailable",
@@ -523,9 +530,7 @@ def _create_embedded_only_page(request: HttpRequest, instance: WidgetInstance):
 
 
 def _create_lti_success_page(request: HttpRequest, instance: WidgetInstance):
-    """
-    TODO should this be under the LTI app?
-    """
+
     is_owner = instance.editable_by_current_user(request.user)
     owner_list = instance.permissions.filter(
         permission=ObjectPermission.PERMISSION_FULL

--- a/app/lti/urls.py
+++ b/app/lti/urls.py
@@ -35,6 +35,7 @@ urlpatterns = [
     path(
         "preview-embed/<slug:widget_instance_id>/",
         WidgetPreviewView.as_view(),
+        {"is_embed": True},
         name="embedded widget preview",
     ),
 ]

--- a/src/components/widget-player-page.jsx
+++ b/src/components/widget-player-page.jsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect} from 'react'
 import Header from './header'
 import WidgetPlayer from './widget-player'
-import useCreatePlaySession from './hooks/useCreatePlaySession'
 import { waitForWindow } from '../util/wait-for-window'
 
 const EMBED = 'embed'
@@ -13,7 +12,7 @@ const LEGACY_EMBED = 'legacy-embed'
 
 const getWidgetType = path => {
 	switch(true) {
-		case path.includes('/embed/'): return EMBED
+		case (path.includes('/embed/') || !!state.ltiToken): return EMBED
 		case path.includes('/play/'): return PLAY
 		case path.includes('/preview/'): return PREVIEW
 		case path.includes('/demo'): return DEMO
@@ -24,8 +23,6 @@ const getWidgetType = path => {
 }
 
 const WidgetPlayerPage = () => {
-
-	const createPlaySession = useCreatePlaySession()
 
 	const type = getWidgetType(window.location.pathname)
 	const nameArr = window.location.pathname.replace(`/${type}/`, '').split('/')


### PR DESCRIPTION
This was mostly an oversight, `is_embedded` wasn't being passed as a parameter to `_create_player_context()`.

Additionally, ensures the embed view will kick in in situations where `/embed/` isn't present but an LTI token is, and removed a leftover reference to `useCreatePlaySession`, since play sessions are no longer initialized via POST requests.