### PR TITLE
Add health check endpoint in nginx conf

### DIFF
--- a/docker/config/nginx/sites-enabled/site.conf
+++ b/docker/config/nginx/sites-enabled/site.conf
@@ -50,4 +50,10 @@ server {
 	location /widget/ {
 		try_files $uri =404;
 	}
+
+	# ELB health check endpoint
+	location /health/ {
+        add_header Content-Type text/plain;
+        return 200 'ok';
+    }
 }


### PR DESCRIPTION
adds /health/ endpoint to catch traffic from ELB health check before reaching gunicorn

After merging, update IaC to move ELB health check from `/` to `/health/`