### PR TITLE
Nginx enginecore solution

### DIFF
--- a/docker/config/nginx/dev/asset-redirect.conf
+++ b/docker/config/nginx/dev/asset-redirect.conf
@@ -6,13 +6,12 @@ server {
     listen *:80;
     server_name _;
 
-    location ~* ^/(js|css)/(.+)$ {
-        return 301 /static/dist/$1/$2;
-    }
     location ~* ^/js/(.+)$ {
-        return 302 /static/dist/js/$1;
-    }
-    location ~* ^/css/(.+)$ {
-        return 302 /static/dist/css/$1;
+		return 302 $scheme://$http_host/static/dist/js/$1;
+	}
+
+    # Does not affect the enginecore.js file
+    location ~* ^/(js|css)/(.+)$ {
+        return 301 /dist/$1/$2;
     }
 }

--- a/docker/config/nginx/dev/asset-redirect.conf
+++ b/docker/config/nginx/dev/asset-redirect.conf
@@ -5,8 +5,14 @@
 server {
     listen *:80;
     server_name _;
-    
+
     location ~* ^/(js|css)/(.+)$ {
-        return 301 /dist/$1/$2;
+        return 301 /static/dist/$1/$2;
+    }
+    location ~* ^/js/(.+)$ {
+        return 302 /static/dist/js/$1;
+    }
+    location ~* ^/css/(.+)$ {
+        return 302 /static/dist/css/$1;
     }
 }

--- a/docker/config/nginx/sites-enabled/site.conf
+++ b/docker/config/nginx/sites-enabled/site.conf
@@ -40,12 +40,6 @@ server {
 		# expires 1d;
 	}
 
-	location ~* ^/js/materia.enginecore.js$ {
-		access_log /dev/stderr main;
-		error_log /dev/stderr info;
-		return 302 $scheme://$http_host/static/dist/js/materia.enginecore.js;
-	}
-
 	location /js {
 		alias /var/www/html/staticfiles/js;
 		autoindex on;
@@ -56,16 +50,5 @@ server {
 	location /widget/ {
 		try_files $uri =404;
 	}
-
-	# location ~* ^/(js|css)/(.+)$ {
-	# 		return 301 /static/dist/$1/$2;
-	# }
-	location ~* ^/js/(.+)$ {
-		return 302 $scheme://$http_host/static/dist/js/$1;
-	}
-	# location ~* ^/css/(.+)$ {
-	# 		return 302 /static/dist/css/$1;
-	# }
-
 
 }

--- a/docker/config/nginx/sites-enabled/site.conf
+++ b/docker/config/nginx/sites-enabled/site.conf
@@ -40,6 +40,12 @@ server {
 		# expires 1d;
 	}
 
+	location ~* ^/js/materia.enginecore.js$ {
+		access_log /dev/stderr main;
+		error_log /dev/stderr info;
+		return 302 $scheme://$http_host/static/dist/js/materia.enginecore.js;
+	}
+
 	location /js {
 		alias /var/www/html/staticfiles/js;
 		autoindex on;
@@ -50,4 +56,16 @@ server {
 	location /widget/ {
 		try_files $uri =404;
 	}
+
+	# location ~* ^/(js|css)/(.+)$ {
+	# 		return 301 /static/dist/$1/$2;
+	# }
+	location ~* ^/js/(.+)$ {
+		return 302 $scheme://$http_host/static/dist/js/$1;
+	}
+	# location ~* ^/css/(.+)$ {
+	# 		return 302 /static/dist/css/$1;
+	# }
+
+
 }


### PR DESCRIPTION
This PR updates the dev nginx asset redirect configuration so that materia.enginecore.js is properly resolved and served in the Django dev environment.

What changed
	•	Adjusted [docker/config/nginx/dev/asset-redirect.conf](https://github.com/ucfcdl/Materia/blob/62a325429f5c6bb4e258e0098bf7a54e11d947b1/docker/config/nginx/dev/asset-redirect.conf#L8) location/redirect rules to include materia.enginecore.js in the dev asset redirect path.  ￼

Why
	•	EngineCore depends on materia.enginecore.js.
	•	Before this change, requests for that bundle weren’t matching the existing dev redirect rules, leading to missing/404 assets and broken EngineCore loads.
	•	This aligns EngineCore asset handling with the rest of the dev static pipeline.

How I tested
	•	Rebuilt and ran the dev stack with nginx enabled.
	•	Verified that requesting materia.enginecore.js and the bundle loads in-browser.

Notes
	•	Scope is limited to dev nginx config only; production behavior is unchanged.