### PR TITLE
Various fixes and polish

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -452,6 +452,23 @@ class PlayLogUpdateSerializer(serializers.Serializer):
             )
 
 
+class PlaySessionCreateSerializer(serializers.Serializer):
+    instanceId = serializers.CharField()
+    is_preview = serializers.BooleanField(required=False)
+
+    def validate(self, data):
+        is_preview = data.get("is_preview", False)
+        instance = WidgetInstance.objects.get(pk=data["instanceId"])
+        if not instance:
+            raise serializers.ValidationError(
+                f"Instance ID {data["InstanceId"]} invalid."
+            )
+
+        if not instance.playable_by_current_user(self.context["request"].user):
+            raise serializers.ValidationError("Instance not playable by current user.")
+        return {"instance": instance, "is_preview": is_preview}
+
+
 # play session model (kinda) serializer (outbound)
 class PlaySessionSerializer(serializers.ModelSerializer):
     inst_name = serializers.CharField(source="instance.name", read_only=True)

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -616,7 +616,7 @@ class ScoreSummarySerializer(serializers.Serializer):
                 }
             )
 
-        return sorted(results, key=lambda x: (x["year"], x["term"]))
+        return sorted(results, key=lambda x: (x["year"], x["term"]), reverse=True)
 
 
 # Used for incoming requests for qset generation. Does NOT map to a model.

--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -4,13 +4,19 @@ import traceback
 from api.filters import LogPlayFilterBackend
 from api.paginators import PageNumberWithTotalPagination
 from api.permissions import PlaySessionInstancePermissions
-from api.serializers import PlayLogUpdateSerializer, PlaySessionSerializer
+from api.serializers import (
+    PlayLogUpdateSerializer,
+    PlaySessionCreateSerializer,
+    PlaySessionSerializer,
+)
 from core.message_exception import MsgFailure, MsgInvalidInput
 from core.models import Log, LogPlay, WidgetInstance
 from core.services.perm_service import PermService
+from core.services.widget_play_services import WidgetPlayInitService
 from core.utils.validator_util import ValidatorUtil
 from django.conf import settings
 from django.db.models import Max
+from django.http import JsonResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from lti.ags.client import AGSClient
 from lti.ags.exceptions.ags_claim_not_defined import AGSClaimNotDefined
@@ -111,7 +117,43 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
         return PlaySessionSerializer
 
     def create(self, request):
-        raise MethodNotAllowed("POST")
+        """
+        Note that while the play sessions API supports POST requests for play session init,
+        this endpoint is only intended for use by embedded demos in the detail carousel.
+        """
+        serializer = PlaySessionCreateSerializer(
+            data=request.data, context={"request": request}
+        )
+
+        if serializer.is_valid(raise_exception=True):
+            validated = serializer.validated_data
+            if validated["is_preview"] is True:
+                preview_id = WidgetPlayInitService.init_preview(request)
+                return JsonResponse({"playId": preview_id})
+            else:
+                user = (
+                    request.user
+                    if validated["instance"].guest_access is False
+                    else None
+                )
+
+                # disallow plays for non-playable widget engines
+                if not validated["instance"].widget.is_playable:
+                    raise MsgFailure(
+                        "Failed to Create Play Session", "This widget is not playable."
+                    )
+
+                # init the new play
+                new_play = WidgetPlayInitService.init_play(
+                    request, validated["instance"], user
+                )
+                if not new_play.id:
+                    raise MsgFailure(
+                        "Failed to Create Play Session",
+                        "There was an error starting your play session. Please try again.",
+                    )
+
+                return JsonResponse({"playId": new_play.id})
 
     def update(self, request, pk=None):
         if not pk:

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -298,17 +298,16 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
             {"lock_obtained": WidgetInstanceService.get_lock(instance.id, request.user)}
         )
 
-    # TODO should this be under /instances or /scores ?
     @action(detail=True, methods=["get"])
     def performance(self, request, pk=None):
         instance = self.get_object()
 
-        logs_for_user = (
+        logs = (
             LogPlay.objects.filter(instance=instance, is_complete=True)
             .order_by("-created_at", "semester")
             .select_related("semester")
         )
-        summary = ScoreSummarySerializer.create_from_plays(logs_for_user)
+        summary = ScoreSummarySerializer.create_from_plays(logs)
 
         serialized = ScoreSummarySerializer(data=summary, many=True)
         serialized.is_valid(raise_exception=True)

--- a/app/core/views/scores.py
+++ b/app/core/views/scores.py
@@ -41,9 +41,6 @@ class ScoresView(MateriaLoginMixin, TemplateView):
         return self.render_to_response(context)
 
 
-# Allow LTI launches to score screens
-# In Canvas, this is shown on the grade review
-# enabled by launch param ext_outcome_data_values_accepted=url
 class ScoresViewSingle(MateriaLoginMixin, TemplateView):
     template_name = "react.html"
     allow_all_by_default = True
@@ -53,6 +50,11 @@ class ScoresViewSingle(MateriaLoginMixin, TemplateView):
         play_id = kwargs.get("play_id")
         widget_instance_id = kwargs.get("widget_instance_id")
         token = request.GET.get("token")
+
+        # Swap if play_id is shorter than widget_instance_id
+        # Why? Because the LTI 1.1 implementation provided /scores/single/play_id/inst_id/ as the score submission URI
+        if len(play_id) < len(widget_instance_id):
+            play_id, widget_instance_id = widget_instance_id, play_id
 
         # Grab and verify play
         play = LogPlay.objects.get(pk=play_id)

--- a/src/components/score-page.jsx
+++ b/src/components/score-page.jsx
@@ -20,6 +20,12 @@ const ScorePage = () => {
 		isEmbed = urlElements[3] == "embed/"
 		instID = urlElements[4]
 		playID = urlElements[5]
+
+		// edge case handler for /scores/single/playID/instID
+		// required to support previous score submissions in LMSs; these URIs are stored by the LMS so we need to continue to support them
+		if (playID && instID && playID.length < instID.length) {
+			[instID, playID] = [playID, instID]
+		}
 	}
 
 

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -173,7 +173,7 @@ const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedd
 				}
 			}
 		} else if (!!instanceScoresError) {
-			if (instanceScoresError.message == "Permission Denied") {
+			if (instanceScoresError.status == 401) {
 				setErrorState(STATE_RESTRICTED)
 			} else {
 				setErrorState(STATE_INVALID)
@@ -238,9 +238,17 @@ const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedd
 			}))
 		}
 		else if (!!playScoresError) {
-			if (playScoresError.message == "Permission Denied") setErrorState(STATE_RESTRICTED)
-			else if (isPreview) setErrorState(STATE_EXPIRED)
-			else setErrorState(STATE_INVALID)
+			switch (playScoresError.status) {
+				case 410:
+					setErrorState(STATE_EXPIRED)
+					break
+				case 401:
+					setErrorState(STATE_RESTRICTED)
+					break
+				default:
+					setErrorState(STATE_INVALID)
+					break
+			}
 		}
 		// @TODO handle errors
 	}, [playScores, playScoresError])
@@ -424,9 +432,10 @@ const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedd
 				errorStateRender = (
 					<div className="invalid container general">
 						<section className="page score_restrict">
-							<h2 className="logo">Play ID Invalid</h2>
-							<p>Well, that's awkward. We couldn't find any play scores to show you. Some common issues associated with this message:</p>
+							<h2 className="logo">Something Went Wrong</h2>
+							<p>Well, that's awkward. Something is preventing us from showing you this score. Some common issues associated with this message:</p>
 							<ul>
+								<li>You accessed this score in a way Materia didn't expect.</li>
 								<li>Materia doesn't think you have the right permissions to view this score.</li>
 								<li>There was an issue with displaying the score screen in this particular context - have you tried accessing it from the widget's Student Activity section or your profile page?</li>
 							</ul>

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -52,6 +52,7 @@ $preview-purple: #b944cc;
 		background: #fff;
 
 		.page {
+			padding-bottom: 2em;
 			font-size: 1em;
 			font-weight: 400;
 			text-align: center;
@@ -64,7 +65,7 @@ $preview-purple: #b944cc;
 			}
 
 			p {
-				margin: 0 0 1em 0;
+				margin: 0 1em 1em 1em;
 			}
 
 			ul {

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -522,6 +522,9 @@ article {
 				}
 
 				li {
+					&.previous-context {
+						background: #111317;
+					}
 					&:hover {
 						background-color: #1b304b;
 					}


### PR DESCRIPTION
Resolves the following issues:

1. #186 by adding edge case checks for instance and play IDs based on string length and swapping them if necessary
2. #180 by restoring `POST /api/play-sessions/` as utilized by the detail carousel. This was too difficult to decouple, at least right now.
3. #169 by ensuring `/api/scores/` and `/api/scores/details/` errors are evaluated based on status codes instead of message content.
4. Adds a missing dark mode style to the reworked Previous Attempts drop-down on the score screen.
5. Fix for `/api/instances/<inst id>/performance/` sorting oldest-to-newest instead of newest-to-oldest