### PR TITLE
Enable qset question location for widgets that don't use 'items', auto-ID answers in question sets.

### DIFF
--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1308,7 +1308,7 @@ class WidgetQset(models.Model):
         decoded_data = Base64Util.decode(self.data)
         # in most cases the top level key in a qset will be 'items'
         # sometimes it won't be - this should work no matter what it is
-        raw_items = decoded_data.get(iter(decoded_data), [])
+        raw_items = decoded_data.get(next(iter(decoded_data)), [])
 
         def find_questions(source):
             questions = []

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1368,22 +1368,25 @@ class WidgetQset(models.Model):
         import copy
         import uuid
 
-        def _process_item(item):
+        def _assign_item_id_if_empty(item):
+            if "id" in item and (
+                item["id"] is None or item["id"] == 0 or item["id"] == ""
+            ):
+                item["id"] = str(uuid.uuid4())
+
+        def _process_item(item, parent_key=None):
             if isinstance(item, list):
-                return [_process_item(element) for element in item]
+                return [_process_item(element, parent_key) for element in item]
 
             if isinstance(item, dict):
                 result = copy.deepcopy(item)
 
-                if Question.is_question(result):
-                    if "id" in result and (
-                        result["id"] is None or result["id"] == 0 or result["id"] == ""
-                    ):
-                        result["id"] = str(uuid.uuid4())
+                if Question.is_question(result) or parent_key == "answers":
+                    _assign_item_id_if_empty(result)
 
                 for key, value in result.items():
                     if isinstance(value, (dict, list)):
-                        result[key] = _process_item(value)
+                        result[key] = _process_item(value, key)
 
                 return result
 

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1305,10 +1305,6 @@ class WidgetQset(models.Model):
         This method will effectively be invoked once per qset at most,
         as subsequent requests for questions will be able to use the ORM
         """
-        decoded_data = Base64Util.decode(self.data)
-        # in most cases the top level key in a qset will be 'items'
-        # sometimes it won't be - this should work no matter what it is
-        raw_items = decoded_data.get(next(iter(decoded_data)), [])
 
         def find_questions(source):
             questions = []
@@ -1334,7 +1330,8 @@ class WidgetQset(models.Model):
 
             return questions
 
-        questions = find_questions(raw_items)
+        decoded_data = Base64Util.decode(self.data)
+        questions = find_questions(decoded_data)
         questions_set = []
         for question in questions:
             new_question = Question(

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1306,7 +1306,9 @@ class WidgetQset(models.Model):
         as subsequent requests for questions will be able to use the ORM
         """
         decoded_data = Base64Util.decode(self.data)
-        raw_items = decoded_data.get("items", [])
+        # in most cases the top level key in a qset will be 'items'
+        # sometimes it won't be - this should work no matter what it is
+        raw_items = decoded_data.get(iter(decoded_data), [])
 
         def find_questions(source):
             questions = []


### PR DESCRIPTION
Closes #188.
Closes #196.

Changes `process_and_create_questions` method in `WidgetQset` model to identify the key of the primary storage layer and use it instead of hard requiring the top layer to be 'items'.

Adds a step to the same method to identify answers and set their `id`s to UUIDs similar to questions.