### PR TITLE
Update filter regex to process special characters.

### DIFF
--- a/src/components/catalog.jsx
+++ b/src/components/catalog.jsx
@@ -62,7 +62,7 @@ const Catalog = ({widgets = [], isLoading = true}) => {
 		// search widget names
 		if(state.searchText !== '') {
 			isFiltered = true
-			const re = new RegExp(state.searchText, 'i')
+			const re = new RegExp(RegExp.escape(state.searchText), 'i')
 			results = results.filter(w => re.test(w.name))
 		}
 

--- a/src/components/lti/select-item.jsx
+++ b/src/components/lti/select-item.jsx
@@ -26,7 +26,7 @@ const SelectItem = () => {
 		const result = new Set()
 		if(searchText == '') return result
 
-		const re = RegExp(searchText, 'i')
+		const re = RegExp(RegExp.escape(searchText), 'i')
 		if (instanceList.instances && instanceList.instances.length > 0)
 			instanceList.instances.forEach(i => {
 				if(!re.test(`${i.name} ${i.widget.name} ${i.id}`)){
@@ -93,7 +93,7 @@ const SelectItem = () => {
 				const form = document.createElement('form')
 				form.method = 'POST'
 				form.action = window.RETURN_URL
-				
+
 				// append embed url to form
 				// @TODO update with 1.3 launch URL?
 				const inputUrl = createFormItem('instance', selectedInstance.embed_url)
@@ -102,7 +102,7 @@ const SelectItem = () => {
 				// append resource name to form
 				const inputName = createFormItem('name', `${selectedInstance.name} Materia Widget`)
 				form.appendChild(inputName)
-				
+
 				// append CSRF token to form
 				const inputCsrf = createFormItem('csrfmiddlewaretoken', getCSRFToken())
 				form.appendChild(inputCsrf)

--- a/src/components/my-widgets-side-bar.jsx
+++ b/src/components/my-widgets-side-bar.jsx
@@ -9,7 +9,7 @@ const MyWidgetsSideBar = ({ instances, isFetching, selectedId, onClick, beardMod
 		const result = new Set()
 		if (searchText == '') return result
 
-		const re = RegExp(searchText, 'i')
+		const re = RegExp(RegExp.escape(searchText), 'i')
 		instances.forEach(i => {
 			if (!re.test(`${i.name} ${i.widget.name} ${i.id}`)) {
 				result.add(i.id)
@@ -40,7 +40,7 @@ const MyWidgetsSideBar = ({ instances, isFetching, selectedId, onClick, beardMod
 
 	let searchBoxRender = null
 	if (isFetching) {
-		searchBoxRender = 
+		searchBoxRender =
 		<div className='search loading'>
 			<LoadingIcon size='sm' width='20px' left='10px'/>
 			<span className='loading-message'>Loading Widgets...</span>


### PR DESCRIPTION
## Fix: Escape special regex characters in catalog search

### Problem
Entering special regex characters (e.g., `/`, `\`, `[`, `]`, `(`, `)`, `*`, `+`, `?`, `.`, `^`, `$`, `|`, `{`, `}`) in the catalog search bar caused a `SyntaxError: Invalid regular expression` and broke the application.

### Solution
Added an `escapeRegex` helper function that escapes special regex characters before creating the RegExp. Updated the search filter to use the escaped search text.

### Changes
- Added `escapeRegex` helper function to escape special regex characters
- Updated RegExp creation on line 70 to use `escapeRegex(state.searchText)` instead of raw `state.searchText`

### Testing
- Search now handles special characters without errors
- Case-insensitive search behavior is preserved
- Normal text searches continue to work as expected

Fixes the regex syntax error when users enter special characters in the search bar.

----
Apologise for the formating