### PR TITLE
Redirect to original location after SAML (or other custom) logins.

### DIFF
--- a/app/core/views/login.py
+++ b/app/core/views/login.py
@@ -8,6 +8,9 @@ from django.shortcuts import redirect, render
 
 
 def login(request):
+    post_login_route = request.GET.get("next", None)
+    if post_login_route:
+        request.session["redirect_url"] = post_login_route
     # allow for custom authentication backend usage to launch from the regular /login route
     custom_auth_redirect = os.environ.get("AUTH_LOGIN_ROUTE_OVERRIDE", False)
     if custom_auth_redirect and custom_auth_redirect.lower() != "false":


### PR DESCRIPTION
Closes #190.

Adds a session variable to persist login redirect targets through potential nonstandard (e.g. SAML) authentication methods.

For UCF purposes, there is a corresponding pull request in the relevant auth package repository: [https://github.com/ucfcdl/materia-django-auth/pull/5](https://github.com/ucfcdl/materia-django-auth/pull/5).