### PR TITLE
Fix Widget API queryset bug, harden 'My Instances' page

### DIFF
--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -147,8 +147,8 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         is_student = PermService.user_is_student(self.request.user)
 
         # Check to see if this widget is editable
-        if is_draft and not widget.is_editable:
-            raise ValidationError("Non-editable widgets cannot be saved as drafts")
+        if not widget.is_editable:
+            raise ValidationError("Non-editable widgets cannot be created")
 
         # Make sure user can publish this widget
         if not is_draft and not widget.publishable_by(self.request.user):
@@ -173,8 +173,8 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         )
 
         # Check to see if this widget is editable
-        if is_draft and not instance.widget.is_editable:
-            raise ValidationError("Non-editable widgets cannot be saved as drafts")
+        if not instance.widget.is_editable:
+            raise ValidationError("Non-editable widgets cannot be updated")
 
         # Make sure user can publish this widget
         if not is_draft and not instance.widget.publishable_by(self.request.user):

--- a/app/api/views/widgets.py
+++ b/app/api/views/widgets.py
@@ -23,6 +23,10 @@ class WidgetViewSet(viewsets.ModelViewSet):
     queryset = Widget.objects.all()
 
     def get_queryset(self):
+        if self.action != "list":
+            # return a default queryset for detail views
+            return Widget.objects.all()
+
         widget_ids_raw = self.request.query_params.get("ids", "")
         widget_type = self.request.query_params.get("type", "catalog")
 

--- a/public/img/warning.svg
+++ b/public/img/warning.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24"><path fill="currentColor" d="M1 21L12 2l11 19zm3.45-2h15.1L12 6zM12 18q.425 0 .713-.288T13 17t-.288-.712T12 16t-.712.288T11 17t.288.713T12 18m-1-3h2v-5h-2zm1-2.5"/></svg>

--- a/src/components/my-widgets-page.scss
+++ b/src/components/my-widgets-page.scss
@@ -471,7 +471,7 @@
 								right: 0.7em;
 							}
 
-							&:hover {
+							&:hover:not(.disabled) {
 								fill: #a2c129;
 								background: none;
 							}
@@ -1200,7 +1200,7 @@
 		}
 
 		.share-widget-container {
-			
+
 			.share-widget-options-first {
 				border-left: 8px solid rgba(239, 129, 82, 0.5);
 			}
@@ -1294,7 +1294,7 @@
 			section.directions {
 
 				&.unchosen {
-					
+
 					min-height: 650px;
 
 					&:not(.bearded), &.bearded {
@@ -1364,7 +1364,7 @@
 						padding: 10px;
 						margin: 0 auto;
 					}
-					
+
 					.controls {
 						width: auto;
 						height: auto;

--- a/src/components/my-widgets-selected-instance.jsx
+++ b/src/components/my-widgets-selected-instance.jsx
@@ -12,6 +12,7 @@ import MyWidgetsWarningDialog from './my-widgets-warning-dialog'
 import MyWidgetsSettingsDialog from './my-widgets-settings-dialog'
 import Modal from './modal'
 import LoadingIcon from './loading-icon'
+import Warning from "@/components/warning";
 
 const convertAvailabilityDates = (startDateStr, endDateStr) => {
 	let endDate, endTime, open_at, startTime
@@ -374,116 +375,124 @@ const MyWidgetSelectedInstance = ({
 		</div>
 			<button id='scroll-to-widget-list' onClick={scrollToInstances}>Widget Selection</button>
 			<div className='overview'>
-			<div className={`icon_container med_${beardMode ? beard : ''} ${beardMode ? 'big_bearded' : ''}`} >
-				<img className='icon'
-					src={iconUrl(`${window.location.origin}/widget/`, inst.widget.dir, 275)}
-					height='275px'
-					width='275px'
-					alt={inst.widget.name}
-				/>
-			</div>
-			<div className='controls'>
-				<ul className='button-list'>
-					<li className='preview_holder'>
-						<a id='preview_button'
-							className={`action-button green ${ !inst.widget.is_playable ? 'disabled' : '' }`}
-							target='_blank'
-							role="button"
-							href={inst.preview_url}>
-							<svg className='preview-svg' viewBox='-40 32 155 70' width='125'>
-								<path d='M 108 44 H 11 a 30 30 90 1 0 0 45 H 108 C 110 89 111 88 111 86 V 47 C 111 45 110 44 108 44'
-								/>
-								<polyline points='-15 51.5 -15 81.5 5 66.5'
-									fill='#4c5823'
-								/>
-							</svg>
-							<span className=''>Preview</span>
-						</a>
-					</li>
-					<li>
-						<a id='edit_button'
-							tabIndex="0"
-							role="button"
-							className={`action-button aux_button ${state.perms.editable ? '' : 'disabled'} `}
-							disabled={state.perms.editable}
-							onClick={editClickHandler}>
-							<span className='pencil'></span>
-							Edit Widget
-						</a>
-					</li>
-				</ul>
-				<ul className='options' role='menu'>
-					<li className='share'>
-						<div className={`link ${state.perms.stale || permsFetching ? 'disabled' : ''}`}
-							role='menuitem'
-							tabIndex="0"
-							onClick={collaborateClickHandler}>
-							{collabLabel}
-						</div>
-					</li>
-					<li className={`copy ${state.can.copy ? '' : 'disabled'}`}>
-						<div className={`link ${state.can.copy ? '' : 'disabled'}`}
-							role='menuitem'
-							aria-disabled={!state.can.copy}
-							tabIndex="0"
-							id='copy_widget_link'
-							onClick={copyClickHandler}>
-							Make a Copy
-						</div>
-					</li>
-					<li className={`delete ${state.can.delete ? '' : 'disabled'}`}>
-						<div className={`link ${state.can.delete ? '' : 'disabled'}`}
-							role='menuitem'
-							aria-disabled={!state.can.delete}
-							tabIndex="0"
-							id='delete_widget_link'
-							onClick={deleteClickHandler}>
-							Delete
-						</div>
-					</li>
-				</ul>
+				<div className={`icon_container med_${beardMode ? beard : ''} ${beardMode ? 'big_bearded' : ''}`} >
+					<img className='icon'
+						src={iconUrl(`${window.location.origin}/widget/`, inst.widget.dir, 275)}
+						height='275px'
+						width='275px'
+						alt={inst.widget.name}
+					/>
+				</div>
+				<div className='controls'>
+					<ul className='button-list'>
+						<li className='preview_holder'>
+							<a id='preview_button'
+								className={`action-button green ${ !inst.widget.is_playable ? 'disabled' : '' }`}
+								target='_blank'
+								role="button"
+								href={inst.widget.is_playable ? inst.preview_url : null}>
+								<svg className='preview-svg' viewBox='-40 32 155 70' width='125'>
+									<path d='M 108 44 H 11 a 30 30 90 1 0 0 45 H 108 C 110 89 111 88 111 86 V 47 C 111 45 110 44 108 44'
+									/>
+									<polyline points='-15 51.5 -15 81.5 5 66.5'
+										fill='#4c5823'
+									/>
+								</svg>
+								<span className=''>Preview</span>
+							</a>
+						</li>
+						<li>
+							<a id='edit_button'
+								tabIndex="0"
+								role="button"
+								className={`action-button aux_button ${state.perms.editable ? '' : 'disabled'} `}
+								disabled={state.perms.editable}
+								onClick={editClickHandler}>
+								<span className='pencil'></span>
+								Edit Widget
+							</a>
+						</li>
+					</ul>
+					<ul className='options' role='menu'>
+						<li className='share'>
+							<div className={`link ${state.perms.stale || permsFetching ? 'disabled' : ''}`}
+								role='menuitem'
+								tabIndex="0"
+								onClick={collaborateClickHandler}>
+								{collabLabel}
+							</div>
+						</li>
+						<li className={`copy ${state.can.copy ? '' : 'disabled'}`}>
+							<div className={`link ${state.can.copy ? '' : 'disabled'}`}
+								role='menuitem'
+								aria-disabled={!state.can.copy}
+								tabIndex="0"
+								id='copy_widget_link'
+								onClick={copyClickHandler}>
+								Make a Copy
+							</div>
+						</li>
+						<li className={`delete ${state.can.delete ? '' : 'disabled'}`}>
+							<div className={`link ${state.can.delete ? '' : 'disabled'}`}
+								role='menuitem'
+								aria-disabled={!state.can.delete}
+								tabIndex="0"
+								id='delete_widget_link'
+								onClick={deleteClickHandler}>
+								Delete
+							</div>
+						</li>
+					</ul>
 
-				{ deleteDialogRender }
+					{ deleteDialogRender }
 
-				<div className={`additional_options ${!state.can.share || inst.is_draft ? 'disabled' : '' }`}>
-					<h3>Settings:</h3>
-					<dl className={`attempts_parent ${!state.can.share || inst.is_draft ? 'disabled' : ''}`}>
-						<dt>Attempts:</dt>
-						<dd
-							className={`num-attempts ${!state.can.edit || !state.can.share || inst.is_draft ? 'disabled' : ''}`}
+					<div className={`additional_options ${!state.can.share || inst.is_draft ? 'disabled' : '' }`}>
+						<h3>Settings:</h3>
+						<dl className={`attempts_parent ${!state.can.share || inst.is_draft ? 'disabled' : ''}`}>
+							<dt>Attempts:</dt>
+							<dd
+								className={`num-attempts ${!state.can.edit || !state.can.share || inst.is_draft ? 'disabled' : ''}`}
+								onClick={onPopup}>
+								{ attempts > 0 ? attempts : 'Unlimited' }
+							</dd>
+							<dt>Available:</dt>
+							<dd
+								className={`availability-time ${!state.can.share || inst.is_draft ? 'disabled' : ''}`}
+								onClick={onPopup}>
+								{ openAnytimeRender }
+								{ openUntilRender }
+								{ anytimeAfterRender }
+								{ fromToRender }
+							</dd>
+							<dt>Access:</dt>
+							<dd
+								className={`access-level ${!state.can.share || inst.is_draft ? 'disabled' : ''}`}
+								onClick={onPopup}>
+								<span>
+									{inst.guest_access ? 'Guest Mode - No Login Required' : 'Staff and Students only'}
+								</span>
+							</dd>
+						</dl>
+						<a id='edit-availability-button'
+							role='button'
+							tabIndex="0"
+							className={!state.can.share || inst.is_draft ? 'disabled' : ''}
+							disabled={!state.can.share || inst.is_draft}
+							aria-disabled={!state.can.share || inst.is_draft}
 							onClick={onPopup}>
-							{ attempts > 0 ? attempts : 'Unlimited' }
-						</dd>
-						<dt>Available:</dt>
-						<dd
-							className={`availability-time ${!state.can.share || inst.is_draft ? 'disabled' : ''}`}
-							onClick={onPopup}>
-							{ openAnytimeRender }
-							{ openUntilRender }
-							{ anytimeAfterRender }
-							{ fromToRender }
-						</dd>
-						<dt>Access:</dt>
-						<dd
-							className={`access-level ${!state.can.share || inst.is_draft ? 'disabled' : ''}`}
-							onClick={onPopup}>
-							<span>
-								{inst.guest_access ? 'Guest Mode - No Login Required' : 'Staff and Students only'}
-							</span>
-						</dd>
-					</dl>
-					<a id='edit-availability-button'
-						role='button'
-						tabIndex="0"
-						className={!state.can.share || inst.is_draft ? 'disabled' : ''}
-						disabled={!state.can.share || inst.is_draft}
-						aria-disabled={!state.can.share || inst.is_draft}
-						onClick={onPopup}>
-						{inst.is_draft ? 'Publish to Edit Settings' : 'Edit Settings'}
-					</a>
+							{inst.is_draft ? 'Publish to Edit Settings' : 'Edit Settings'}
+						</a>
+					</div>
 				</div>
 			</div>
-				</div>
+
+			{/* Widget disabled warnings */}
+			{ !inst.widget.is_playable && !inst.widget.is_editable ?
+				<Warning>All '{inst.widget.name}' widgets are currently disabled.</Warning> : null }
+			{ !inst.widget.is_playable && inst.widget.is_editable ?
+				<Warning>All '{inst.widget.name}' widgets are currently not playable.</Warning> : null }
+			{ inst.widget.is_playable && !inst.widget.is_editable ?
+				<Warning>All '{inst.widget.name}' widgets are currently not editable.</Warning> : null }
 
 			<div className={`share-widget-container closed ${inst.is_draft ? 'draft' : ''}`}>
 				<h3>

--- a/src/components/warning.jsx
+++ b/src/components/warning.jsx
@@ -1,0 +1,15 @@
+import React from 'react'
+import './warning.scss'
+
+const Warning = ({
+  children = '',
+}) => {
+  return (
+    <div className="warning-container">
+      <img className="warning-icon" src="/img/warning.svg" alt="" />
+      {children}
+    </div>
+  )
+}
+
+export default Warning

--- a/src/components/warning.scss
+++ b/src/components/warning.scss
@@ -1,0 +1,31 @@
+.warning-container {
+  display: flex;
+  align-items: center;
+  box-sizing: border-box;
+  background-color: var(--warning-bkg-color);
+  opacity: 0.9;
+  margin: 0 20px;
+  padding: 10px 15px;
+  border: 1px solid var(--warning-border-color);
+  border-left-width: 5px;
+  border-radius: 3px;
+  gap: 15px;
+
+  & .warning-icon {
+    width: 22px;
+    opacity: 0.6;
+  }
+
+  --warning-bkg-color: #FFFFCCFF;
+  --warning-border-color: #c5c59b;
+}
+
+.darkMode .warning-container {
+  --warning-bkg-color: #5e5e38;
+  --warning-border-color: #8d8d55;
+
+  & .warning-icon {
+    filter: invert(1);
+    opacity: 0.8;
+  }
+}

--- a/src/components/warning.scss
+++ b/src/components/warning.scss
@@ -11,17 +11,19 @@
   border-radius: 3px;
   gap: 15px;
 
+  font-weight: 400;
+
   & .warning-icon {
     width: 22px;
     opacity: 0.6;
   }
 
-  --warning-bkg-color: #FFFFCCFF;
+  --warning-bkg-color: #ffeca8;
   --warning-border-color: #c5c59b;
 }
 
 .darkMode .warning-container {
-  --warning-bkg-color: #5e5e38;
+  --warning-bkg-color: #353226;
   --warning-border-color: #8d8d55;
 
   & .warning-icon {


### PR DESCRIPTION
This PR addresses the issues raised in #172 

Changes:
- The widget API `get_queryset` function will now return an unfiltered queryset if the action isn't `list`. Much of the filtering that was taking place only useful for the `list` action, anyway.
- All attempts to create or update a widget that has `is_editable` set to false are rejected now. Before, they were only rejected if the widget was a draft.
- Added a new warning on the 'My Instances' page that appears on instances when a widget has `is_playable` disabled, `is_editable` disabled, or both.
- The 'preview' button on a widget instance no longer changes color when hovered over while disabled.

<img width="1035" height="499" alt="image" src="https://github.com/user-attachments/assets/e299380e-c862-4b04-b2b3-3d79412e24cd" />
