### PR TITLE
Fix creator race condition

### DIFF
--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -70,17 +70,17 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 	/* =========== react queries =========== */
 
 	// load widget info (NOT instance info)
+	// load only when instId is not set (new widget)
 	// requires: widgetId prop (always set)
 	const { isLoading: widgetInfoIsLoading } = useQuery({
 		queryKey: ['widget', widgetId],
 		queryFn: () => apiGetWidget(widgetId),
-		enabled: !!widgetId,
+		enabled: !!widgetId && !instId,
 		staleTime: Infinity,
 		retry: false,
 		onSuccess: (info) => {
 			if (info) {
 				setInstance({ ...instance, widget: info[0] })
-				setCreatorState({...creatorState, canGenerateQset: info[0]['is_generable']})
 			}
 		},
 		onError: (error) => {
@@ -121,8 +121,12 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 	useEffect(() => {
 		if ( !qsetQuery.isLoading && qsetQuery.data != null ) {
 			if (qsetQuery.isSuccess && qsetQuery.data != undefined) {
-				setCreatorState({...creatorState, invalid: false})
-				setInstance({ ...instance, qset: qsetQuery.data })
+				setCreatorState((curCreatorState) => {
+					return {...curCreatorState, invalid: false}
+				})
+				setInstance((curInstData) => {
+					return { ...curInstData, qset: qsetQuery.data }
+				})
 			} else {
 				onInitFail(qsetQuery.error)
 			}
@@ -224,32 +228,38 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 	},[widgetReady])
 
 	useEffect(() => {
-
 		if (instance.id) {
 			instIdRef.current = instance.id
-			setCreatorState({
-				...creatorState,
-				publishText: !instance.is_draft ? 'Update' : 'Publish...',
-				mode: !instance.is_draft ? 'update' : 'edit',
-				returnUrl: getMyWidgetsUrl(instance.id),
-				returnLocation: 'My Widgets'
+			setCreatorState((curCreatorState) => {
+				return {
+					...curCreatorState,
+					publishText: !instance.is_draft ? 'Update' : 'Publish...',
+					mode: !instance.is_draft ? 'update' : 'edit',
+					returnUrl: getMyWidgetsUrl(instance.id),
+					returnLocation: 'My Widgets'
+				}
 			})
 		} else {
-			setCreatorState({...creatorState, returnUrl: `${window.BASE_URL}widgets`, returnLocation: 'Widget Catalog'})
+			setCreatorState((curCreatorState) => {
+				return {...curCreatorState, returnUrl: `${window.BASE_URL}widgets`, returnLocation: 'Widget Catalog'}
+			})
 		}
 
 	}, [instance])
 
 	useEffect(() => {
 		if (instance.widget) {
-			let creatorPath = instance.widget.creator.substring(0, 4) === 'http' ? 
-				instance.widget.creator : 
+			let creatorPath = instance.widget.creator.substring(0, 4) === 'http' ?
+				instance.widget.creator :
 				window.WIDGET_URL.replace(/\/$/, '') + '/' + instance.widget.dir + instance.widget.creator
 
-			setCreatorState({
-				...creatorState,
-				creatorPath: creatorPath + '?' + instance.widget.created_at,
-				hasCreatorGuide: instance.widget.creator_guide != ''
+			setCreatorState((curCreatorState) => {
+				return {
+					...curCreatorState,
+					creatorPath: creatorPath + '?' + instance.widget.created_at,
+					hasCreatorGuide: instance.widget.creator_guide != '',
+					canGenerateQset: !!instance.widget.is_generable
+				}
 			})
 		}
 	}, [instance.widget])
@@ -817,8 +827,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 
 
 	let actionBarRender = null
-	if (creatorState.showActionBar) {
-
+	if (creatorState.showActionBar && (!instanceIsLoading && !widgetInfoIsLoading)) {
 		let returnLocationUrl = creatorState.returnLocation == 'Widget Catalog' ? '/widgets' : '/my-widgets#' + instance.id
 
 		actionBarRender = (


### PR DESCRIPTION
Resolves #199, which describes an issue where due to a race condition, the creator action bar might show the incorrect buttons for a published widget (e.g. the 'publish' and 'save draft' buttons would appear, instead of the normal 'update' button).

In the creator page, a few `useEffect` hooks update the same variable - `creatorState`, often in the same rerender. Under certain circumstances, such as when an instance's qset finishes loading before the instance's data, this can cause a loss of data where new data calculated in an earlier useEffect is overridden by the old data still present in a later useEffect. To resolve this, most `setCreatorState` calls were converted to their lambda function form, which will always use the latest available current state.

This appears to work great, and has even potentially cleared up some other rare issues. For example, sometimes, some existing instances would initialize as if they were new widgets (e.g. showing an initial 'name this widget' modal, etc.), even though the qset was loaded in. With these changes, I haven't been able to replicate that anymore.

Additionally, I've added these minor QoL changes:
- Added an extra check to prevent the action bar from rendering if the widget or instance data are still loading. This prevents any of the buttons from showing until we actually know details about the instance. For published widgets, the draft versions of the buttons would always flash for a split second before being replaced with the published version buttons. This does not happen anymore.
- Added a check to prevent running a separate query for widget engine info when we are editing a non-new widget (one already with an instance ID). The instance details query already provides the widget engine data, so this additional query was unnecessary. It will still run for brand new instances, though.