### PR TITLE
Login override support for widget pre-embed views

### DIFF
--- a/app/core/views/login.py
+++ b/app/core/views/login.py
@@ -15,7 +15,7 @@ def login(request):
     custom_auth_redirect = os.environ.get("AUTH_LOGIN_ROUTE_OVERRIDE", False)
     if custom_auth_redirect and custom_auth_redirect.lower() != "false":
         # also allow for explicitly bypassing the custom authentication backend
-        if "directlogin" in request.GET:
+        if "directlogin" in request.GET or "show_pre_embed" in request.GET:
             # do nothing, proceed with regular login handling
             pass
         else:

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -1,4 +1,5 @@
 import logging
+import os
 
 from core.mixins import (
     MateriaLoginMixin,
@@ -123,6 +124,20 @@ class WidgetPlayView(
         )
 
         return validation
+
+    def get_login_url(self):
+        """
+        Utilized by MateriaLoginMixin, pass show_pre_embed as an additional url param
+        when AUTH_LOGIN_ROUTE_OVERRIDE is active
+        This enables the "Login" button in pre-embed contexts, and the login component distinguishes
+        show_pre_embed from directlogin to render different content
+        """
+        if os.environ.get("AUTH_LOGIN_ROUTE_OVERRIDE", False):
+            login_url_base = self.login_url or settings.LOGIN_URL
+            login_url_with_param = f"{login_url_base}?show_pre_embed=1"
+            return login_url_with_param
+        else:
+            return super().get_login_url()
 
     def process_context(self, validation):
         return _create_player_context(

--- a/src/components/login-page.jsx
+++ b/src/components/login-page.jsx
@@ -48,13 +48,13 @@ const LoginPage = () => {
 	if (!state.context || state.context == 'login') {
 		detailContent =
 		<div className="login_context detail">
-			<h2 className="context-header">Log In to Your Account</h2>
+			<h2 className="context-header">Login to Your Account</h2>
 			<LoginSubtitle />
 		</div>
 	} else if (state.context && state.context == 'widget') {
 		detailContent =
 		<div className="login_context detail">
-			<h2 className="context-header">Log in to play this widget</h2>
+			<h2 className="context-header">Login to play this widget</h2>
 			<LoginSubtitle />
 		</div>
 	}

--- a/src/login.js
+++ b/src/login.js
@@ -1,7 +1,7 @@
 import React from 'react'
 import {createRoot} from 'react-dom/client'
 import { QueryClient, QueryClientProvider, QueryCache } from 'react-query'
-import LoginPage from './components/login-page'
+import LoginPage from '@/components/login-page'
 
 const queryCache = new QueryCache()
 export const queryClient = new QueryClient({ queryCache })


### PR DESCRIPTION
- If the `MateriaLoginMixin` redirects widget play requests to the login page for authentication, appends a `?show_pre_embed=1` URL param. This param causes pre-embed views to bypass login overrides, much like `?directlogin=1`.
- This param is picked up by the UCF-specific login page to render a login link, and allows it to differentiate from `directlogin` which renders the service user login form.