### PR TITLE
Fix is_generable/uses_prompt_generation flags

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -166,6 +166,8 @@ class WidgetSerializer(serializers.ModelSerializer):
     meta_data = serializers.JSONField(source="metadata", required=False)
     dir = serializers.CharField(read_only=True)
     creator = serializers.SerializerMethodField()
+    is_generable = serializers.SerializerMethodField()
+    uses_prompt_generation = serializers.SerializerMethodField()
 
     def get_creator(self, widget):
         """
@@ -176,6 +178,18 @@ class WidgetSerializer(serializers.ModelSerializer):
             return settings.URLS["STATIC_CROSSDOMAIN"] + "default-creator/creator.html"
         else:
             return widget.creator
+
+    def get_is_generable(self, widget):
+        """
+        Returns true only if the widget supports generation AND AI features are enabled on this Materia install.
+        """
+        return widget.is_generable and settings.AI_GENERATION["ENABLED"]
+
+    def get_uses_prompt_generation(self, widget):
+        """
+        Returns true only if the widget supports prompt generation AND AI features are enabled on this Materia install.
+        """
+        return widget.uses_prompt_generation and settings.AI_GENERATION["ENABLED"]
 
     class Meta:
         model = Widget


### PR DESCRIPTION
Resolves #210 

As it stands, the serializers do not modify a widget's `is_generable` or `uses_prompt_generation` flags to `False` if the current Materia install has AI features disabled. This allows those features to appear on the front-end, even if disabled on the backend.

This PR adds methods for the Widget serializer's `is_generable` and `uses_prompt_generation` fields to fix this.