### PR TITLE
Render widget titles with weird characters correctly in the embed screen.

### DIFF
--- a/src/components/widget-summary.jsx
+++ b/src/components/widget-summary.jsx
@@ -24,7 +24,7 @@ const Summary = () => {
 					<img src={ icon } alt=""/>
 				</div>
 				<ul className="widget_about">
-					{ name && <li className="widget_name">{ name }</li>}
+					{ name && <li className="widget_name" dangerouslySetInnerHTML={{ __html: name }}></li>}
 					{ avail && <li className="widget_availability">{ avail }</li>}
 				</ul>
 			</section>


### PR DESCRIPTION
Closes #221.

Correctly renders 'unsafe' characters in widget instance titles on the pre-login screen for embedded widgets.