### PR TITLE
LTI fixes (the real one)

### DIFF
--- a/app/lti/mixins.py
+++ b/app/lti/mixins.py
@@ -1,7 +1,6 @@
 import logging
 
 from core.message_exception import MsgFailure
-from django.contrib.auth import logout
 from lti.services.auth import LTIAuthService
 from lti.services.launch import LTILaunchService
 
@@ -16,7 +15,7 @@ class LtiLaunchMixin:
         launch = LTILaunchService.get_or_recover_launch(request)
         if launch is not None:
             try:
-                # handle_lti_launch performs LTI authentication
+                # handle_lti_launch performs LTI auth check, if necessary
                 self.handle_lti_launch(request, launch)
             except Exception:
                 return self.on_lti_launch_failure(request)
@@ -34,8 +33,9 @@ class LtiLaunchMixin:
 
     def handle_lti_launch(self, request, launch):
 
-        # launch auth depends on launch state: initial or recovery
-        # for recovery launches, verify the authenticated user matches the user stored in the launch
+        # auth checks depend on launch type
+        # if launch state is INITIAL, auth has just occurred
+        # for RECOVERY launches, verify the authenticated user matches the user stored in the launch
         if LTILaunchService.get_launch_state(launch) == "RECOVERY":
             launch_username = LTIAuthService.get_username_from_launch(launch)
 
@@ -46,17 +46,6 @@ class LtiLaunchMixin:
                     f"{request.user.username} and {launch_username}!"
                 )
                 raise MsgFailure(msg="LTI Launch recovery authentication mismatch")
-
-        # destroy current authentication session if active
-        if request.user and request.user.is_authenticated:
-            logout(request)
-            request.session.flush()
-
-        # authenticate from LTI launch payload
-        auth = LTIAuthService.authenticate(request, launch)
-
-        if auth is None:
-            raise Exception("LTI authentication failed")
 
     # called on successful launch and authentication
     # this method is intended to be overridden by views where the mixin is referenced

--- a/app/lti/views/init.py
+++ b/app/lti/views/init.py
@@ -1,5 +1,4 @@
 import logging
-import re
 
 from django.conf import settings
 from lti_tool.views import OIDCLoginInitView
@@ -10,29 +9,11 @@ logger = logging.getLogger(__name__)
 class MateriaOIDCLoginInitView(OIDCLoginInitView):
 
     def get_redirect_url(self, target_link_uri: str) -> str:
-
-        if self.requires_redirect(target_link_uri):
-            redirect = f"{settings.URLS["BASE_URL"]}ltilaunch/"
-            return redirect
-
-        return target_link_uri
-
-    def requires_redirect(self, target_link_uri: str) -> bool:
-
-        # embed URL - used for widget plays
-        if re.search(r"embed/[A-Za-z0-9]{5,}/[A-Za-z0-9\-]*/?$", target_link_uri):
-            return True
-
-        # modern score URL - inst_id/play_id, used for submission review
-        elif re.search(
-            r"scores/single/[A-Za-z0-9]{5,}/[A-Za-z0-9\-]*/?$", target_link_uri
-        ):
-            return True
-
-        # former score URL - play_id/inst_id, for some reason
-        elif re.search(
-            r"scores/single/[A-Za-z0-9\-]*/[A-Za-z0-9]{5,}/?$", target_link_uri
-        ):
-            return True
-
-        return False
+        """
+        Overrides OIDCLoginInitView's `get_redirect_url` method, as we only have one whitelisted launch URI: /ltilaunch/
+        LTI 1.3 requires all launch URIs to be whitelisted in platform's LTI key
+        From the launch view (lti/views/launch.py), handle_resource_launch and handle_deep_linking_launch actually send
+        the user where they want to go
+        """
+        redirect = f"{settings.URLS["BASE_URL"]}ltilaunch/"
+        return redirect


### PR DESCRIPTION
- Fixes unnecessary session destruction that prevented recovered launches from occurring
- Fixes OIDC init override using an incomplete whitelist to check whether to update the redirect URI. Now, the redirect URI to /ltilaunch/ is always sent back, since it's the only valid one anyhow.

