### PR TITLE
Fixes score overview not being hidden

### DIFF
--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -351,12 +351,12 @@ const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedd
 						case 'setHeight':
 							return setHeight(msg.data[0])
 						case 'hideResultsTable':
-							return setAttributes({...attributes, showResultsTable: false})
+							return setAttributes(prevAttributes => ({...prevAttributes, showResultsTable: false}))
 						case 'hideScoresOverview':
-							return (playData?.overview?.complete ?
-								setAttributes({...attributes, showScoresOverview: false}) :
-								setAttributes({...attributes, showScoresOverview: true})
-							)
+							return setAttributes(prevAttributes => ({
+								...prevAttributes,
+								showScoresOverview: playData?.overview?.complete ? false : true
+							}))
 						case 'requestScoreDistribution':
 							// @TODO
 							// return loadScoreDistribution()


### PR DESCRIPTION
Closes issue #217 

### Summary
The `onPostMessage` handler was using stale `attributes` data when calling `setAttributes()`. This resulted in `showScoresOverview` always reverting to true even after being set to false. So, using the functional form of setState, which ensures the latest attribute values are always accessed.

### Testing
Installed Simple Survey, a widget that shouldn't display a score overview and ensured that it doesn't
Installed Associations, a widget that should display a score overview and ensured that it does