### PR TITLE
Rework to Launch Service's `get_or_recover_launch`

### DIFF
--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -107,7 +107,7 @@ class WidgetPlayView(
 
     def get_validation(self, request, instance):
         context_id = ""
-        launch = LTILaunchService.get_or_recover_launch(request)
+        launch = LTILaunchService.get_or_recover_widget_launch(request)
         if launch is not None:
             context_id = LTILaunchService.get_context_id(launch)
 
@@ -156,7 +156,7 @@ class WidgetPlayView(
 
         # do we have an LTI launch?
         # if it is - update the play with LTI flags and pass the token to context
-        launch = LTILaunchService.get_or_recover_launch(self.request)
+        launch = LTILaunchService.get_or_recover_widget_launch(self.request)
         if launch and not instance.guest_access:
             play.auth = "lti"
             play.context_id = LTILaunchService.get_context_id(launch)

--- a/app/lti/mixins.py
+++ b/app/lti/mixins.py
@@ -12,7 +12,7 @@ class LtiLaunchMixin:
     # dispatch is called prior to view processing and lets us perform checks associated with LTI launches
     def dispatch(self, request, *args, **kwargs):
 
-        launch = LTILaunchService.get_or_recover_launch(request)
+        launch = LTILaunchService.get_or_recover_widget_launch(request)
         if launch is not None:
             try:
                 # handle_lti_launch performs LTI auth check, if necessary

--- a/app/lti/services/launch.py
+++ b/app/lti/services/launch.py
@@ -184,15 +184,13 @@ class LTILaunchService:
         lid: launch id. This is the uuid created by pylti1p3. Provided in initial resource launch.
         token: play id. Used to recover a launch that's already been put into session.
         """
-        if LTILaunchService.is_lti_launch(request):
-            launch_id = request.GET.get("lid", None)
-            if launch_id is not None:
-                launch = get_launch_from_request(request, launch_id)
-                launch_data = None if launch is None else launch.get_launch_data()
-                launch_data["materia_launch_state"] = "INITIAL"
-                return launch_data
+        launch_id = request.GET.get("lid", None)
+        if launch_id is not None:
+            launch = get_launch_from_request(request, launch_id)
+            launch_data = None if launch is None else launch.get_launch_data()
+            launch_data["materia_launch_state"] = "INITIAL"
+            return launch_data
 
-            return None
         else:
             token_param = request.GET.get("token")
             recovery = LTILaunchService.get_session_launch(request, token_param)

--- a/app/lti/services/launch.py
+++ b/app/lti/services/launch.py
@@ -102,7 +102,7 @@ class LTILaunchService:
         return deployment.registration if deployment is not None else None
 
     @staticmethod
-    def get_launch_redirect(lti_launch: LtiLaunch):
+    def get_launch_redirect(lti_launch: LtiLaunch) -> str:
         """
         Gets the appropriate redirect URI for resource link launches.
         Should be one of three destinations: post login, widget player, or score screen
@@ -139,9 +139,9 @@ class LTILaunchService:
         return None
 
     @staticmethod
-    def is_widget_launch(launch_data):
+    def is_widget_launch(launch_data) -> bool:
         """
-        TODO how else can we determine whether it's a widget launch from LTI claim data?
+        Identifies whether a given launch is a widget launch by inspecting the target_link_uri.
         """
         uri_claim = launch_data.get(
             "https://purl.imsglobal.org/spec/lti/claim/target_link_uri"

--- a/app/lti/services/launch.py
+++ b/app/lti/services/launch.py
@@ -3,6 +3,7 @@ import re
 
 from core.models import Lti
 from lti_tool.models import LtiDeployment, LtiLaunch
+from lti_tool.utils import get_launch_from_request
 
 # from pprint import pformat
 
@@ -101,27 +102,38 @@ class LTILaunchService:
         return deployment.registration if deployment is not None else None
 
     @staticmethod
-    def get_launch_redirect(launch_data):
+    def get_launch_redirect(lti_launch: LtiLaunch):
         """
-        Most LTI launches come in as LtiResourceLinkRequests
-        We determine the destination view by checking the target_link_uri value in the launch claim
+        Gets the appropriate redirect URI for resource link launches.
+        Should be one of three destinations: post login, widget player, or score screen
         """
+        launch_data = lti_launch.get_launch_data()
         uri_claim = launch_data.get(
             "https://purl.imsglobal.org/spec/lti/claim/target_link_uri"
         )
 
-        # not a widget launch - redirect to post-login landing page
+        # no redirect or a redirect to /ltilaunch? Send them to post-login
         if not uri_claim or re.search("/ltilaunch/", uri_claim):
             return "/lti/post_login/"
 
+        # widget launches require special processing
+        # we provide the launch ID as a query param so we can distinguish LTI plays from non-LTI
+        # referencing request.lti_launch is NOT enough because one may be cached in session
+        elif LTILaunchService.is_widget_launch(launch_data):
+            lid = lti_launch.get_launch_id()
+            uri_claim = f"{uri_claim}?lid={lid}"
+            return uri_claim
+
+        # expected to be a score screen at this point
         else:
-            # widget or score url redirect - do we need to verify this?
             return uri_claim
 
     @staticmethod
     def get_inst_id_from_uri(uri_claim):
 
-        res = re.search(r"embed/([A-Za-z0-9\-]{5,})/[A-Za-z0-9\-]*/?$", uri_claim)
+        res = re.search(
+            r"(?:embed|play)/([A-Za-z0-9\-]{5,})/[A-Za-z0-9\-]*/?$", uri_claim
+        )
         if res:
             return res.group(1)
         return None
@@ -135,7 +147,7 @@ class LTILaunchService:
             "https://purl.imsglobal.org/spec/lti/claim/target_link_uri"
         )
 
-        if re.search(r"embed/[A-Za-z0-9]{5,}/[A-Za-z0-9\-]*/?$", uri_claim):
+        if re.search(r"(?:embed|play)/[A-Za-z0-9]{5,}/[A-Za-z0-9\-]*/?$", uri_claim):
             return True
 
         return False
@@ -143,8 +155,7 @@ class LTILaunchService:
     @staticmethod
     def is_lti_launch(request):
         if hasattr(request, "lti_launch") and request.lti_launch:
-            return isinstance(request.lti_launch, LtiLaunch)
-
+            return request.lti_launch.is_present
         return False
 
     @staticmethod
@@ -166,11 +177,22 @@ class LTILaunchService:
         return launch.get("materia_launch_state", None)
 
     @staticmethod
-    def get_or_recover_launch(request):
+    def get_or_recover_widget_launch(request):
+        """
+        Gets the launch data associated with a widget launch.
+        Requires one of two query params to be present:
+        lid: launch id. This is the uuid created by pylti1p3. Provided in initial resource launch.
+        token: play id. Used to recover a launch that's already been put into session.
+        """
         if LTILaunchService.is_lti_launch(request):
-            launch = request.lti_launch.get_launch_data()
-            launch["materia_launch_state"] = "INITIAL"
-            return launch
+            launch_id = request.GET.get("lid", None)
+            if launch_id is not None:
+                launch = get_launch_from_request(request, launch_id)
+                launch_data = None if launch is None else launch.get_launch_data()
+                launch_data["materia_launch_state"] = "INITIAL"
+                return launch_data
+
+            return None
         else:
             token_param = request.GET.get("token")
             recovery = LTILaunchService.get_session_launch(request, token_param)

--- a/app/lti/services/launch.py
+++ b/app/lti/services/launch.py
@@ -193,11 +193,14 @@ class LTILaunchService:
 
         else:
             token_param = request.GET.get("token")
-            recovery = LTILaunchService.get_session_launch(request, token_param)
-            if recovery is not None:
-                recovery["materia_launch_state"] = "RECOVERY"
+            if token_param is not None:
+                recovery = LTILaunchService.get_session_launch(request, token_param)
+                if recovery is not None:
+                    recovery["materia_launch_state"] = "RECOVERY"
 
-            return recovery
+                return recovery
+
+        return None
 
     @staticmethod
     def store_session_launch(request, key, launch):

--- a/app/lti/views/launch.py
+++ b/app/lti/views/launch.py
@@ -12,14 +12,13 @@ logger = logging.getLogger(__name__)
 class ApplicationLaunchView(LtiLaunchBaseView):
     def handle_resource_launch(self, request, lti_launch):
         launch_data = lti_launch.get_launch_data()
-
         auth = LTIAuthService.authenticate(request, launch_data)
 
         if not auth:
             logger.error("launch login invalid")
             return error_page(request, "error_unknown_user")
 
-        destination = LTILaunchService.get_launch_redirect(launch_data)
+        destination = LTILaunchService.get_launch_redirect(lti_launch)
         return redirect(destination)
 
     def handle_deep_linking_launch(self, request, lti_launch):

--- a/app/lti/views/lti.py
+++ b/app/lti/views/lti.py
@@ -26,8 +26,8 @@ def post_login(request):
     #     LTILaunchService.store_session_launch(request, context_id, launch)
     # =============================================
     is_author = False
-    launch = LTILaunchService.get_or_recover_launch(request)
-    if launch is not None:
+    if LTILaunchService.is_lti_launch(request):
+        launch = request.lti_launch.get_launch_data()
         is_author = LTIAuthService.is_user_course_author(launch)
 
     context = ContextUtil.create(


### PR DESCRIPTION
### The problem

Previously, `get_or_recover_launch` would simply check for `request.lti_launch` to see if a given request was an LTI launch. The problem is that the `django-lti` middleware caches launches in session, and attaches session-stored launches to `request.lti_launch` - meaning we can't rely on `request.lti_launch` as a source of truth for whether a given request is actually a launch.

This has the particularly nasty effect of causing non-LTI plays - like visits to a widget's play URL directly - to be upgraded to LTI plays due to the presence of a seemingly valid `request.lti_launch` object. It meant that a non-LTI play could mistakenly cause an AGS submission to the resource link provided in the cached launch.

### The solution?

`pylti1p3` generates a launch ID when it stores the launch in session. When an _actual_ LTI widget launch occurs - via `handle_resource_launch` - we attach the launch ID as a query param to the play/embed URL, to indicate an actual LTI launch is occurring. The launch ID is used to recover the desired launch from session, and `get_or_recover_launch` (now `get_or_recover_widget_launch`) proceeds as it did before.

Notably, the change to `get_or_recover_widget_launch` means it will _not_ return a launch object unless the launch ID (via `?lid=`) or a recovery token (via `?token=`) is present in the request's GET params. 
