### PR TITLE
Restores ability to constrain widget instance plays to embed-only contexts.

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -28,7 +28,7 @@ from django.contrib.auth.models import User
 from django.db import transaction
 from rest_framework import serializers
 
-logger = logging.getLogger(__name__)
+logger = logging.getLogger("django")
 
 
 # Asset model serializer
@@ -313,6 +313,7 @@ class WidgetInstanceSerializer(serializers.ModelSerializer):
     preview_url = serializers.CharField(read_only=True)
     play_url = serializers.CharField(read_only=True)
     embed_url = serializers.CharField(read_only=True, allow_null=True)
+    is_embedded = serializers.BooleanField(read_only=True)
     qset = QuestionSetSerializer(required=False)
 
     # remove sensitive info if context flag set
@@ -384,6 +385,7 @@ class WidgetInstanceSerializer(serializers.ModelSerializer):
             "preview_url",
             "play_url",
             "embed_url",
+            "is_embedded",
             "qset",
         ]
         read_only_fields = [
@@ -392,6 +394,7 @@ class WidgetInstanceSerializer(serializers.ModelSerializer):
             "is_student_made",
             "widget",
             "widget_id",
+            "is_embedded",
         ]
 
 

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -28,7 +28,7 @@ from django.contrib.auth.models import User
 from django.db import transaction
 from rest_framework import serializers
 
-logger = logging.getLogger("django")
+logger = logging.getLogger(__name__)
 
 
 # Asset model serializer

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1276,6 +1276,10 @@ class WidgetInstance(models.Model):
             return None
         return f"{settings.URLS['BASE_URL']}embed/{self.id}/{slugify(self.name)}/"
 
+    @property
+    def is_embedded(self):
+        return self.lti_embeds.count() > 0
+
     @classproperty
     def content_type(cls):
         return ContentType.objects.get_for_model(cls)

--- a/app/core/services/widget_play_services.py
+++ b/app/core/services/widget_play_services.py
@@ -97,7 +97,7 @@ class WidgetPlayValidationService:
 
         autoplay = parse_bool(request.GET.get("autoplay", None), True)
 
-        if not is_embedded and instance.embedded_only:
+        if not is_preview and not is_embedded and instance.embedded_only:
             return WidgetPlayValidationService.INVALID_EMBEDDED_ONLY
 
         if not instance.playable_by_current_user(request.user):

--- a/src/components/support-selected-instance.jsx
+++ b/src/components/support-selected-instance.jsx
@@ -205,8 +205,8 @@ const SupportSelectedInstance = ({inst, currentUser, onCopySuccess, embed = fals
 			open_at: u.open_at,
 			close_at: u.close_at,
 			attempts: u.attempts,
-			guest_access: u.guest_access,
-			embedded_only: u.embedded_only,
+			guestAccess: u.guest_access,
+			embeddedOnly: u.embedded_only,
 		}
 
 		updateWidget.mutate({

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -235,14 +235,14 @@ export const apiCanEditWidgets = arrayOfWidgetIds => {
 export const apiUpdateWidgetInstance = ({ args }) => {
 	// limit args to the following params
 	const body = {
-		name: args?.name ?? undefined,
-		qset: args?.qset ?? undefined,
-		is_draft: args?.isDraft ?? undefined,
+		name: args?.name,
+		qset: args?.qset,
+		is_draft: args?.isDraft,
 		open_at: args?.openAt,
 		close_at: args?.closeAt,
-		attempts: args?.attempts ?? undefined,
-		guest_access: args?.guestAccess ?? undefined,
-		embedded_only: args?.embeddedOnly ?? undefined,
+		attempts: args?.attempts,
+		guest_access: args?.guestAccess,
+		embedded_only: args?.embeddedOnly,
 	}
 	return handleRequest(methods.PATCH, `/api/instances/${args.id}/`, body)
 }


### PR DESCRIPTION
Closes #241.

* Null coalesce operators in the frontend code were (somehow) erroneously converting values of `false` to `undefined` which was preventing certain values from updating properly. Luckily when using optional chaining it's redundant to null coalesce to `undefined`.
  * Also had to rename the args being sent from the admin/support widget instance management components to match expectations in the API utility.

* Added an `is_embedded` property to the widget instance serializer and a corresponding model property to check whether a widget instance has any LTI associations, which should re-enable the 'embedded only' selector in widget settings.