### PR TITLE
Deep linking launch recovery improvements and error handling

### DIFF
--- a/app/lti/views/deep_linking.py
+++ b/app/lti/views/deep_linking.py
@@ -19,23 +19,36 @@ logger = logging.getLogger(__name__)
 def lti_deep_link_selection(request):
     selection = request.POST.get("instance")
     title = request.POST.get("name", "Materia Widget Activity")
+    launch_id = request.POST.get("lid", None)
 
     if not selection:
         return error_page(request, "error_unknown_assignment")
 
     # notably, this request will NOT have an associated LTI launch
-    # we have to grab the original LTI launch ID from session cache and then
-    # use that to grab the original launch from DjangoCacheDataStorage
-    cached_launch_id = request.session["lti-deep-link"]
-    if not cached_launch_id:
-        return error_page(request)
+    # the launch ID should be available from the form, as it is provided to the picker
+    # as a backup, we can also check for it in session
+    # once retrieved, we use the launch ID to grab the original launch from DjangoCacheDataStorage
+    cached_launch_id = launch_id
+    if cached_launch_id is None:
+        try:
+            cached_launch_id = request.session["lti-deep-link"]
+        except Exception:
+            logger.error(
+                f"LTI: ERROR: cached launch ID could not be recovered for deep linking selection of inst: {selection}."
+            )
+            return error_page(request, "error_launch_recovery")
 
-    cached_launch = get_launch_from_request(request, cached_launch_id)
+    try:
+        cached_launch = get_launch_from_request(request, cached_launch_id)
+        resource = DeepLinkResource()
+        resource.set_url(selection).set_title(title)
+        response = cached_launch.deep_link_response([resource])
 
-    resource = DeepLinkResource()
-    resource.set_url(selection).set_title(title)
-
-    response = cached_launch.deep_link_response([resource])
+    except Exception:
+        logger.error(
+            f"LTI: ERROR: could not recover cached launch with ID {cached_launch_id}."
+        )
+        return error_page(request, "error_launch_recovery")
 
     # Clear the deep link session data now that it's no longer needed
     if "lti-deep-link" in request.session:

--- a/app/lti/views/launch.py
+++ b/app/lti/views/launch.py
@@ -30,11 +30,11 @@ class ApplicationLaunchView(LtiLaunchBaseView):
             logger.error("launch login invalid")
             return error_page(request, "error_unknown_user")
 
-        # store the launch ID in session - we'll need to grab this
-        # in the subsequent request that does not have access to the original launch
-        request.session["lti-deep-link"] = lti_launch.get_launch_id()
-
-        return redirect("/lti/picker/")
+        # we need access to the original launch data when sending the deep link selection back to the platform
+        # in addition to a GET param, store the launch ID in session for redundancy
+        launch_id = lti_launch.get_launch_id()
+        request.session["lti-deep-link"] = launch_id
+        return redirect(f"/lti/picker/?lid={launch_id}")
 
     def handle_submission_review_launch(self, request, lti_launch):
         """

--- a/src/components/lti/error-general.jsx
+++ b/src/components/lti/error-general.jsx
@@ -49,6 +49,7 @@ const ErrorGeneral = () => {
         case 'error_lti_guest_mode':
             content =
                 <section id="error-container">
+                    <h4>Error type: Guest Mode Enabled</h4>
                     <p>This assignment has guest mode enabled.</p>
                     <p>This assignment can only record scores anonymously and therefore cannot be played as an embedded assignment.</p>
                     <p>Your instructor will need to disable guest mode or provide a link to play as a guest.</p>
@@ -62,6 +63,13 @@ const ErrorGeneral = () => {
                     <p>We recommend contacting support:</p>
                 </section>
             break;
+        case 'error_launch_recovery':
+            content =
+            <section id="error-container">
+                <h4>Error type: Launch Recovery Failure</h4>
+                <p>Materia couldn't complete this operation because of a session caching issue.</p>
+                <p>This almost certainly isn't because of anything you did. If possible, please report the issue to support.</p>
+            </section>
         default:
             content =
                 <section id="error-container">

--- a/src/components/lti/select-item.jsx
+++ b/src/components/lti/select-item.jsx
@@ -4,8 +4,8 @@ import useInstanceList from '../hooks/useInstanceList'
 import LoadingIcon from '../loading-icon'
 
 const SelectItem = () => {
-	const [strHeader, setStrHeader] = useState('Select a Widget:');
-	const [selectedInstance, setSelectedInstance] = useState(null);
+	const [strHeader, setStrHeader] = useState('Select a Widget:')
+	const [selectedInstance, setSelectedInstance] = useState(null)
 	const [searchText, setSearchText] = useState('')
 	const [easterMode, setEasterMode] = useState(false)
 	const [showRefreshArrow, setShowRefreshArrow] = useState(false)
@@ -13,10 +13,17 @@ const SelectItem = () => {
 	const fillRef = useRef(null)
 	const [progressComplete, setProgressComplete] = useState(false)
 	const [error, setError] = useState("")
+	const [launchID, setLaunchID] = useState('')
 
 	const instanceList = useInstanceList("me")
 
 	useEffect(() => {
+		const params = new URLSearchParams(window.location.search)
+		setLaunchID(params.get('lid') || '')
+	}, [])
+
+	useEffect(() => {
+		// @TODO window.SYSTEM is never defined
 		if (window.SYSTEM) {
 			setStrHeader(`Select a Widget for use in ${window.SYSTEM}:`)
 		}
@@ -93,9 +100,12 @@ const SelectItem = () => {
 				const form = document.createElement('form')
 				form.method = 'POST'
 				form.action = window.RETURN_URL
+				
+				// append launch ID to form - we need it for submission to the platform
+				const inputLaunchID = createFormItem('lid', launchID)
+				form.appendChild(inputLaunchID)
 
 				// append embed url to form
-				// @TODO update with 1.3 launch URL?
 				const inputUrl = createFormItem('instance', selectedInstance.embed_url)
 				form.appendChild(inputUrl)
 


### PR DESCRIPTION
Improvements to launch recovery during the deep linking process, in addition to better error handling:

- The launch ID is still stored in session at the `lti-deep-link` key but it's also appended to the picker URL as a GET parameter.
- The launch ID is now included in the form data submitted to the deep linking submission endpoint.
- Launch recovery defaults to the recovered ID from from form POST data and falls back to the session key if not present.
- Improved exception handling during launch recovery during deep linking submission. Added a "Launch Recovery Failure" error type to the LTI error page.