### PR TITLE
Update lticonfig to allow for link_selection in modules.

### DIFF
--- a/app/lti/templates/lti.json
+++ b/app/lti/templates/lti.json
@@ -27,7 +27,16 @@
               "selection_height":"600",
               "message_type":"LtiDeepLinkingRequest",
               "target_link_uri": "{{ app_hostname }}/ltilaunch/"
-           }
+            },
+            {
+              "text":"Materia Widget",
+              "enabled":true,
+              "placement":"link_selection",
+              "selection_width":"600",
+              "selection_height":"400",
+              "message_type":"LtiDeepLinkingRequest",
+              "target_link_uri": "{{ app_hostname }}/ltilaunch/"
+            }
           ]
         },
         "privacy_level": "public"
@@ -57,4 +66,3 @@
     "target_link_uri": "{{ app_hostname }}/ltilaunch/",
     "oidc_initiation_url": "{{ app_hostname }}/init/{{ registration_uuid }}/"
   }
-  


### PR DESCRIPTION
Add re-linking for external tools on modules in Canvas LMS

<img width="837" height="599" alt="image" src="https://github.com/user-attachments/assets/7bbc60af-ce59-4d0b-9e04-e368cb8c90c4" />
