### PR TITLE
Notifications component improvements

### DIFF
--- a/app/api/permissions.py
+++ b/app/api/permissions.py
@@ -1,17 +1,12 @@
 import logging
 
+from core.models import LogPlay, ObjectPermission, WidgetInstance
+from core.services.instance_service import WidgetInstanceService
+from core.services.perm_service import PermService
 from django.contrib.auth.models import User
-
-from core.models import (
-    LogPlay,
-    ObjectPermission,
-    WidgetInstance,
-)
 from django.db.models import Q
 from django.utils import timezone
 from rest_framework import permissions
-from core.services.perm_service import PermService
-from core.services.instance_service import WidgetInstanceService
 
 logger = logging.getLogger(__name__)
 
@@ -78,6 +73,11 @@ class CanCreateWidgetInstances(permissions.BasePermission):
 
 
 class HasFullPerms(permissions.BasePermission):
+    def has_permission(self, request, view):
+        user = request.user
+        if not user or not user.is_authenticated:
+            return False
+
     def has_object_permission(self, request, view, obj):
         user = request.user
         if not user or not user.is_authenticated:

--- a/app/api/views/notifications.py
+++ b/app/api/views/notifications.py
@@ -1,10 +1,9 @@
+from api.permissions import HasFullPerms, IsSuperOrSupportUser
+from api.serializers import NotificationsSerializer
+from core.models import Notification
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
-
-from core.models import Notification
-from api.permissions import IsSuperOrSupportUser, HasFullPerms
-from api.serializers import NotificationsSerializer
-from rest_framework import viewsets, status
 
 
 class NotificationsViewSet(viewsets.ModelViewSet):

--- a/src/components/notifications.jsx
+++ b/src/components/notifications.jsx
@@ -10,14 +10,14 @@ const Notifications = (user) => {
 	const deleteNotification = useDeleteNotification()
 	const queryClient = useQueryClient()
 	const setUserPerms = setUserInstancePerms()
-	const numNotifications = useRef(0)
+	const [numNotifications, setNumNotifications] = useState(0)
 	const [errorMsg, setErrorMsg] = useState({
 		notif_id: '',
 		msg: ''
 	})
 	let modalRef = useRef()
 
-	const { data: notifications} = useQuery({
+	const { data: notifications, dataUpdatedAt: updatedAt, status, error} = useQuery({
 		queryKey: 'notifications',
 		enabled: !!user && user.loggedIn,
 		refetchInterval: 60000,
@@ -26,20 +26,20 @@ const Notifications = (user) => {
 		queryFn: apiGetNotifications,
 		staleTime: Infinity,
 		retry: false,
-		onSuccess: (data) => {
-			numNotifications.current = 0
-			if (data && data.length > 0) data.forEach(element => {
-				if (!element.remove) numNotifications.current++
-			})
-		},
-		onError: (err) => {
-			if (err.message == "Invalid Login") {
-				window.location.href = '/users/login'
-			} else {
-				console.error(err)
-			}
-		}
 	})
+
+	useEffect(() => {
+		if (status == 'success') {
+			let notificationCount = 0
+			if (notifications && notifications.length > 0) notifications.forEach(element => {
+				if (!element.remove) notificationCount++
+			})
+			setNumNotifications(notificationCount)
+		}
+		else if (status == 'error') {
+			if (error.status == 403 || error.response?.status == 403) window.location.href = '/login?show_pre_embed=1'
+		}
+	},[updatedAt, status])
 
 	// Close notification modal if user clicks outside of it
 	useEffect(() => {
@@ -58,6 +58,10 @@ const Notifications = (user) => {
 			}
 		}
 	}, [navOpen])
+
+	useEffect(() => {
+		if (numNotifications <= 0) setNavOpen(false)
+	},[numNotifications])
 
 	const toggleNavOpen = (event) =>
 	{
@@ -88,7 +92,7 @@ const Notifications = (user) => {
 					if (notifications[key].id == id)
 					{
 						notifications[key].remove = true
-						numNotifications.current--
+						setNumNotifications(numNotifications - 1)
 						return
 					}
 				})
@@ -161,7 +165,6 @@ const Notifications = (user) => {
 				setErrorMsg({notif_id: notif.id, msg: 'Action failed.'})
 			}
 		})
-
 	}
 
 	let render = null
@@ -212,7 +215,7 @@ const Notifications = (user) => {
 
 			notificationIcon =
 			<button id='notifications_link' className='notEmpty'
-				data-notifications={numNotifications.current}
+				data-notifications={numNotifications}
 				onClick={toggleNavOpen}></button>
 
 			notificationElements.push(notifRow)


### PR DESCRIPTION
Resolves #238 

- Uses additional `useQuery` parameters to govern errors and query status instead of `onSuccess` and `onError`
- Updated query error handling to inspect error status code instead of the flimsy message string check
- Added `has_permission` method to `HasFullPerms` with basic authentication check
- Replaced notification count ref with state

Now, when the notifications component receives a 403 error indicating an authentication failure, it correctly redirects the user to the login page (using `?show_pre_embed=1` to avoid immediate redirects).