### PR TITLE
#253 Add widget install commands to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -135,6 +135,16 @@ create-superuser: ## Create a new superuser using the Django `createsuperuser` m
 change-password: ## Change user password using 'changepassword' command. Example: make user=your_username change-password
 	@$(MAKE) run-docker-command DOCKER_COMMAND="python manage.py changepassword $(user)"
 
+## File argument takes the in-container location of the .wigt file
+## Ex. make install-widget-file file="/var/www/html/staticfiles/widget/widget_name-xxxx.wigt" 
+install-widget-file: 
+	@$(MAKE) run-docker-command DOCKER_COMMAND="python manage.py widget install_from_file $(file)"
+
+## URL argument is the url to download from, id argument is optional
+## Ex. make install-widget-url url="http://test.com/widget_name.wigt"
+install-widget-url: 
+	@$(MAKE) run-docker-command DOCKER_COMMAND="python manage.py widget install_from_url_no_verify $(url) $(id)"
+
 lint: lint-backend lint-frontend ## Run backend and frontend linters
 lint-check: lint-backend-check lint-frontend-check ## Run backend and frontend linters in check/no-fix mode
 

--- a/app/core/management/commands/widget.py
+++ b/app/core/management/commands/widget.py
@@ -64,10 +64,12 @@ class Command(base.BaseCommand):
         rmtree(os.path.dirname(local_package))
         rmtree(os.path.dirname(local_checksum))
 
-    def install_from_url_no_verify(self, package_url, desired_id):
+    def install_from_url_no_verify(self, package_url, desired_id=None):
         local_package = self.download_package(package_url)
 
-        self.replace_id = desired_id
+        if desired_id is not None:
+            self.replace_id = desired_id
+            
         self.install(local_package)
 
     def download_package(self, file_url):


### PR DESCRIPTION
Targets https://github.com/ucfcdl/Materia/issues/253

Adds two Makefile commands for installing widgets: `install-widget-file`, and `install-widget-url`.

`install-widget-file` installs a widget from a .wigt file that is stored **in-container**. This is mainly for repairing the MWDK *Install to Docker Materia* function as shown in https://github.com/ucfopen/Materia-Widget-Dev-Kit/pull/144, which relies on this change.

`install-widget-url` installs a widget from a .wigt file downloaded from a URL, which also has a parameter for manually setting an ID to install the widget to. I updated the widget CLI definition to make this ID optional, as Materia already auto-detects the desired widget ID. As I did not have any public URL hosting a .wigt file, I tested this script using a `file://` URL pointing to an in-container file, which worked as expected.