### PR TITLE
Handles legacy answer options format in get_feedback

### DIFF
--- a/app/scoring/module.py
+++ b/app/scoring/module.py
@@ -239,9 +239,11 @@ class ScoreModule(ABC):
         text = log.text if hasattr(log, "text") else log["text"]
         for answer in answers:
             if text == answer["text"]:
-                feedback = answer.get("options", {}).get("feedback", "")
-                if feedback:
-                    return feedback
+                options = answer.get("options", {})
+                if isinstance(options, dict):
+                    feedback = options.get("feedback", "")
+                    if feedback:
+                        return feedback
         return None
 
     def get_detail_style(self, score) -> str:


### PR DESCRIPTION
Fixes #256

## Problem
Some ancient sequencer qsets use `options: []` (list) instead of `options: {}` (dict) in their answer definitions. This caused `get_feedback()` in the base score module to crash with an `AttributeError` when calling `.get()` on a list.

## Solution
Added `isinstance(options, dict)` check before calling `.get()` on the options object to safely handle both dict and list formats.

## Testing
- Tested with modern qsets (options as dict)
- Tested with legacy qsets (options as list)