### PR TITLE
Thread safety changes for widget mixins

### DIFF
--- a/app/core/mixins.py
+++ b/app/core/mixins.py
@@ -15,13 +15,13 @@ class MateriaLoginMixin(AccessMixin):
     login_title: str = None
     login_message: str = None
     login_error: str = None
-    login_global_vars: dict = {}
+    login_global_vars: dict = None
     allow_all_by_default: bool = (
         False  # If true, the default initial_login_check will not check if users is auth'd
     )
 
     def get_login_global_vars(self, request) -> dict:
-        return self.login_global_vars
+        return self.login_global_vars if self.login_global_vars is not None else {}
 
     # By default, will always trigger a login if user is not authenticated.
     # Can be overridden to require logins only in specific scenarios.
@@ -114,9 +114,15 @@ class MateriaWidgetPlayProcessor:
         # ex: widget demos
         inst_id = self.kwargs.get("widget_instance_id", None)
         if inst_id is not None:
-            self.instance = WidgetInstance.objects.filter(pk=inst_id).first()
-            self.is_embedded = kwargs.get("is_embed", False)
-            self.validation = self.get_validation(request, self.instance)
+            instance = WidgetInstance.objects.filter(pk=inst_id).first()
+            is_embedded = kwargs.get("is_embed", False)
+            validation = self.get_validation(request, instance)
+
+            request._widget_play_state = {
+                "instance": instance,
+                "is_embedded": is_embedded,
+                "validation": validation,
+            }
 
         return super().dispatch(request, *args, **kwargs)
 
@@ -126,10 +132,15 @@ class MateriaWidgetPlayProcessor:
         instance_name=None,
         is_embed=False,
     ):
-        processed_context = self.process_context(self.validation)
+        # Retrieve per-request state from request object
+        play_state = getattr(self.request, "_widget_play_state", {})
+        validation = play_state.get("validation")
+        instance = play_state.get("instance")
 
-        if self.validation is WidgetPlayValidationService.VALID:
-            pre_init = self.before_play_init(self.instance)
+        processed_context = self.process_context(validation)
+
+        if validation is WidgetPlayValidationService.VALID:
+            pre_init = self.before_play_init(instance)
 
             ContextUtil.add_global(processed_context, "PLAY_ID", pre_init["play_id"])
             if pre_init["lti_token"] is not None:

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -65,8 +65,14 @@ class WidgetDemoView(MateriaLoginMixin, MateriaWidgetPlayProcessor, TemplateView
         widget_slug = kwargs.get("widget_slug")
         widget = Widget.objects.get(pk=_get_id_from_slug(widget_slug))
         demo_id = widget.metadata.get("demo")
-        self.instance = WidgetInstance.objects.filter(pk=demo_id).first()
-        self.validation = self.get_validation(request, self.instance)
+        instance = WidgetInstance.objects.filter(pk=demo_id).first()
+        validation = self.get_validation(request, instance)
+
+        request._widget_play_state = {
+            "instance": instance,
+            "is_embedded": False,
+            "validation": validation,
+        }
 
         return super().dispatch(request, *args, **kwargs)
 
@@ -87,8 +93,10 @@ class WidgetDemoView(MateriaLoginMixin, MateriaWidgetPlayProcessor, TemplateView
         return validation
 
     def process_context(self, validation):
+        play_state = getattr(self.request, "_widget_play_state", {})
+        instance = play_state.get("instance")
         return _create_player_context(
-            validation, self.instance, self.request, is_preview=False
+            validation, instance, self.request, is_preview=False
         )
 
     def before_play_init(self, instance):
@@ -113,13 +121,14 @@ class WidgetPlayView(
 
         # Check if this instance is a guest/demo instance
         has_guest_access = instance.guest_access
+        is_embedded = self.kwargs.get("is_embed", False)
 
         validation = WidgetPlayValidationService.validate_widget_context(
             request,
             instance,
             has_guest_access=has_guest_access,
             is_preview=False,
-            is_embedded=self.is_embedded,
+            is_embedded=is_embedded,
             context_id=context_id,
         )
 
@@ -140,16 +149,18 @@ class WidgetPlayView(
             return super().get_login_url()
 
     def process_context(self, validation):
+        play_state = getattr(self.request, "_widget_play_state", {})
+        instance = play_state.get("instance")
+        is_embedded = play_state.get("is_embedded", False)
         return _create_player_context(
             validation,
-            self.instance,
+            instance,
             self.request,
             is_preview=False,
-            is_embedded=self.is_embedded,
+            is_embedded=is_embedded,
         )
 
     def before_play_init(self, instance):
-
         user = None if instance.guest_access else self.request.user
         play = WidgetPlayInitService.init_play(self.request, instance, user)
         lti_token = None
@@ -244,12 +255,15 @@ class WidgetPreviewView(MateriaLoginMixin, MateriaWidgetPlayProcessor, TemplateV
         return validation
 
     def process_context(self, validation):
+        play_state = getattr(self.request, "_widget_play_state", {})
+        instance = play_state.get("instance")
+        is_embedded = play_state.get("is_embedded", False)
         return _create_player_context(
             validation,
-            self.instance,
+            instance,
             self.request,
             is_preview=True,
-            is_embedded=self.is_embedded,
+            is_embedded=is_embedded,
         )
 
     def before_play_init(self, instance):


### PR DESCRIPTION
In `MateriaLoginMixin`:
- `login_global_vars` now set to `None` to prevent it from being a mutable default argument and shared across class instances.

In `MateriaWidgetPlayProcessor`:
- `instance`, `is_embedded`, and `validation` are now attached to the request object to prevent potential cross-contamination.