### PR TITLE
Updates scores API to remove redundant score module instantiation

### DIFF
--- a/app/api/views/scores.py
+++ b/app/api/views/scores.py
@@ -78,11 +78,6 @@ class ScoresView(APIView):
 
             scores = []
             for play in plays.order_by("-created_at"):
-                module = ScoreModuleFactory.create_score_module(
-                    instance=instance, play=play
-                )
-
-                details = module.get_score_report()
 
                 current_context = (
                     play.context_id == context and play.semester == semester
@@ -92,7 +87,7 @@ class ScoresView(APIView):
                     {
                         "id": play.id,
                         "created_at": play.created_at.isoformat(),
-                        "percent": details.get("overview", {}).get("score", 0),
+                        "percent": play.percent,
                         "current_context": current_context,
                     }
                 )

--- a/src/components/scores.jsx
+++ b/src/components/scores.jsx
@@ -156,7 +156,7 @@ const Scores = ({ instID, playID: playIDProp, userID, token, contextID, isEmbedd
 					return new Date(a.created_at) - new Date(b.created_at)
 				})
 				for (let score of scores) {
-					score.roundedPercent = parseFloat(score.percent).toFixed(2)
+					score.roundedPercent = Math.round(parseFloat(score.percent))
 					const d = new Date(score.created_at)
 					const date = d.getMonth() + 1 + '/' + d.getDate() + '/' + d.getFullYear()
 					score.date = date


### PR DESCRIPTION
Resolves #268 

Notably, `play.percent` is a double field, so the value initializes at `0`. Also updated the "Prev. Attempts" drop-down to display score percentages as rounded whole numbers instead of 2-digit decimals.