### PR TITLE
Updates to User Admin Panel

### DIFF
--- a/app/api/views/users.py
+++ b/app/api/views/users.py
@@ -57,7 +57,10 @@ class UserViewSet(viewsets.ModelViewSet):
         ]:  # only superusers or support users can modify a limited set of user properties
             permission_classes = [permissions.IsAuthenticated, IsSuperOrSupportUser]
         elif self.action == "roles":  # only superusers can modify another user's roles
-            permission_classes = [permissions.IsAuthenticated, IsSuperuser]
+            if self.request.method == "GET":
+                permission_classes = [permissions.IsAuthenticated, IsSuperOrSupportUser]
+            else:
+                permission_classes = [permissions.IsAuthenticated, IsSuperuser]
         elif self.action in ["perms", "profile_fields"]:
             permission_classes = [IsUserSelf | IsSuperOrSupportUser]
         elif (

--- a/src/components/profile-page.jsx
+++ b/src/components/profile-page.jsx
@@ -89,7 +89,7 @@ const ProfilePage = () => {
 	let noActivityRender = <p className='no_logs'>You don't have any activity! Once you play a widget, your score history will appear here.</p>
 
 	let activityContentRender = activityData.map((record) => {
-			return <li className={`activity_log ${record.is_complete == 1 ? 'complete' : 'incomplete'} ${record.score == 100 ? 'perfect_score' : ''}`} key={record.play_id}>
+			return <li className={`activity_log ${record.is_complete ? 'complete' : 'incomplete'} ${record.score == 100 ? 'perfect_score' : ''}`} key={record.play_id}>
 				<a className='score-link' href={record.link}>
 					<div className="status">{record.status}</div>
 					<div className="widget">{record.widget}</div>

--- a/src/components/user-admin-instance-played.jsx
+++ b/src/components/user-admin-instance-played.jsx
@@ -21,7 +21,7 @@ const UserAdminInstancePlayed = ({play, index}) => {
 					</div>
 				</span>
 				<span className='incomplete-status-holder'>
-					{ parseInt(play.is_complete) ? '' : '[Incomplete]' }
+					{ play.is_complete ? '' : '[Incomplete]' }
 				</span>
 				<span className='date-holder'>
 					{ playedDate.toLocaleDateString() }
@@ -32,16 +32,19 @@ const UserAdminInstancePlayed = ({play, index}) => {
 					<label>Date:</label> { `${playedDate.toLocaleString()}` }
 				</div>
 				<div>
-					<label>Score:</label> <a target="_blank" href={ `/scores/single/${play.play_id}/${play.id}` }>{ play.percent }%</a>
+					<label>Score:</label> <a target="_blank" href={ `/scores/single/${play.instance}/${play.id}` }>{ play.percent }%</a>
 				</div>
 				<div>
 					<label>Time Elapsed:</label> { play.elapsed }s
 				</div>
 				<div>
-					<label>Completed:</label> { play.is_complete == "1" ? 'Yes' : 'No' }
+					<label>Completed:</label> { play.is_complete ? 'Yes' : 'No' }
 				</div>
 				<div>
 					<label>Context:</label> {play.auth && typeof play.auth == 'string' && play.auth.toLowerCase() == 'lti' ? 'LTI' : 'Web' }
+				</div>
+				<div>
+					<label>Context ID:</label> { play.context_id ? play.context_id : 'N/A' }
 				</div>
 			</div>
 		</li>

--- a/src/components/user-admin-selected.jsx
+++ b/src/components/user-admin-selected.jsx
@@ -131,7 +131,7 @@ const UserAdminSelected = ({selectedUser, currentUser, roles, onReturn}) => {
 				</span>
 				<h3>User Settings</h3>
 				<span>
-					<label>Notifications: </label> NYI - Add Me!{ /*updatedUser.profile_fields.notify ? 'Enabled' : 'Disabled' */}
+					<label>Notifications: </label>{ updatedUser.profile_fields.notify ? 'Enabled' : 'Disabled' }
 				</span>
 				<span>
 					<label>User Icon: </label>{ updatedUser.profile_fields.useGravatar ? 'Gravatar' : 'Default' }


### PR DESCRIPTION
Resolves #267 and #266 

- ensures that `is_complete` references treats it as a boolean instead of string/number
    - ensures that play history "Incomplete" show only for incomplete plays and not when uncompleted
- Adds context ID for each play if exists, otherwise N/A
- ensures that the link to score screen for a play works
    - clicked on the link to check that it takes me to the intended score screen for completed/uncompleted plays
- updates notification settings value
    - ensures that once notification settings are enabled, text shows "Notifications: Enabled" and if off, "Notifications: Disabled"
- updates role permissions in the backend gating support and super users
   - ensures that super users can perform read/writes and support users can only read, but not write by performing CURL requests with GET/PUT on different account with different permissions