### PR TITLE
Fall back to qset to identify questions not present in the database.

### DIFF
--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1417,6 +1417,32 @@ class WidgetQset(models.Model):
 
         self.process_and_create_questions()
 
+    def find_item_with_id(decoded, item_id):
+        import copy
+
+        def _process_item(item):
+            if isinstance(item, list):
+                for element in item:
+                    result = _process_item(element)
+                    if result is not None:
+                        return result
+
+            elif isinstance(item, dict):
+                copied_item = copy.deepcopy(item)
+
+                if Question.is_question(copied_item):
+                    if copied_item.get("id") == item_id:
+                        return copied_item
+
+                for value in copied_item.values():
+                    if isinstance(value, (dict, list)):
+                        result = _process_item(value)
+                        if result is not None:
+                            return result
+            return None
+
+        return _process_item(decoded)
+
     class Meta:
         db_table = "widget_qset"
         indexes = [

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1417,6 +1417,7 @@ class WidgetQset(models.Model):
 
         self.process_and_create_questions()
 
+    @staticmethod
     def find_item_with_id(decoded, item_id):
         import copy
 

--- a/app/scoring/module.py
+++ b/app/scoring/module.py
@@ -4,7 +4,7 @@ import logging
 from abc import ABC, abstractmethod
 
 from core.message_exception import MsgInvalidInput
-from core.models import Log, LogPlay
+from core.models import Log, LogPlay, WidgetQset
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +192,11 @@ class ScoreModule(ABC):
         returns the json data of the question, not a question model instance
         """
         question = next((q for q in self.questions if q.item_id == item_id), None)
+        # no matching Question instance was found
+        # see if we can identify this question in the qset
+        if question is None:
+            return WidgetQset.find_item_with_id(self.qset, item_id)
+
         return question.data
 
     def get_score_details(self):


### PR DESCRIPTION
Closes #269.

Adds a method to the `WidgetQset` class to try identifying a question by an item id, for use as a fallback in the event a valid `Question` object is not available.