### PR TITLE
Security updates

### DIFF
--- a/app/api/views/sessions.py
+++ b/app/api/views/sessions.py
@@ -3,6 +3,8 @@ from rest_framework.views import APIView
 
 
 class SessionView(APIView):
+    http_method_names = ["get"]
+
     def get(self, request):
         perm = ""
         if request.user.is_superuser:

--- a/app/materia/settings/apps.py
+++ b/app/materia/settings/apps.py
@@ -11,6 +11,7 @@ INSTALLED_APPS = [
     "rest_framework",
     # apps
     "core",
+    "corsheaders",
     "lti_tool",
     "lti",
 ]

--- a/app/materia/settings/base.py
+++ b/app/materia/settings/base.py
@@ -42,8 +42,7 @@ DIRS = {
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
 # SECURITY WARNING: don't run with debug turned on in production!
-# DEBUG = os.environ.get("DJANGO_ENV", "prod") == "dev"
-DEBUG = False
+DEBUG = os.environ.get("DJANGO_ENV", "prod") == "dev"
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [

--- a/app/materia/settings/base.py
+++ b/app/materia/settings/base.py
@@ -54,7 +54,6 @@ REST_FRAMEWORK = {
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
-    # "core.middleware.WidgetRedirectCOOPMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",

--- a/app/materia/settings/base.py
+++ b/app/materia/settings/base.py
@@ -14,6 +14,7 @@ from .extra import *  # noqa: F401, F403
 from .generation import *  # noqa: F401, F403
 from .js import *  # noqa: F401, F403
 from .lti import *  # noqa: F401, F403
+from .security import *  # noqa: F401, F403
 
 # import additional config files
 from .session import *  # noqa: F401, F403
@@ -37,22 +38,12 @@ DIRS = {
     ),  # + os.sep
 }
 
-SESSION_COOKIE_SAMESITE = "None"
-SESSION_COOKIE_SECURE = True
-CSRF_COOKIE_SAMESITE = "None"
-CSRF_COOKIE_SECURE = True
-CSRF_TRUSTED_ORIGINS = [os.environ.get("BASE_URL").rstrip("/")]
-
 # Quick-start development settings - unsuitable for production
 # See https://docs.djangoproject.com/en/5.0/howto/deployment/checklist/
 
-# SECURITY WARNING: keep the secret key used in production secret!
-SECRET_KEY = "materia-local-dev-secret-key"
-
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = os.environ.get("DJANGO_ENV", "prod") == "dev"
-
-ALLOWED_HOSTS = ["*", "localhost", "127.0.0.1"]
+# DEBUG = os.environ.get("DJANGO_ENV", "prod") == "dev"
+DEBUG = False
 
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
@@ -62,14 +53,14 @@ REST_FRAMEWORK = {
 }
 
 MIDDLEWARE = [
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
+    # "core.middleware.WidgetRedirectCOOPMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
     "django.middleware.common.CommonMiddleware",
     "django.middleware.csrf.CsrfViewMiddleware",
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
-    # "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "lti_tool.middleware.LtiLaunchMiddleware",
 ]

--- a/app/materia/settings/security.py
+++ b/app/materia/settings/security.py
@@ -7,8 +7,6 @@ ALLOWED_HOSTS = [
     .rstrip("/")
     .replace("https://", "")
     .replace("http://", "")
-    .replace("https://", "")
-    .replace("http://", "")
     .split(":")[0]
 ]
 

--- a/app/materia/settings/security.py
+++ b/app/materia/settings/security.py
@@ -1,0 +1,33 @@
+import os
+
+SECRET_KEY = os.environ.get("DJANGO_SECRET_KEY", "materia-local-dev-secret-key")
+
+ALLOWED_HOSTS = [
+    os.environ.get("BASE_URL", "")
+    .rstrip("/")
+    .replace("https://", "")
+    .replace("http://", "")
+    .replace("https://", "")
+    .replace("http://", "")
+    .split(":")[0]
+]
+
+# cookie security
+SESSION_COOKIE_SAMESITE = "None"
+SESSION_COOKIE_SECURE = True
+
+# CSRF configuration
+CSRF_COOKIE_SAMESITE = "None"
+CSRF_COOKIE_SECURE = True
+CSRF_TRUSTED_ORIGINS = [
+    os.environ.get("BASE_URL").rstrip("/"),
+]
+
+# CORS configuration
+CORS_ALLOWED_ORIGINS = [
+    os.environ.get("BASE_URL").rstrip("/"),
+]
+CORS_URLS_REGEX = r"^/api/.*$"
+
+# COOP configuration
+SECURE_CROSS_ORIGIN_OPENER_POLICY = "same-origin-allow-popups"

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -2,6 +2,7 @@ asgiref==3.7.2
 boto3==1.37.23
 botocore==1.37.23
 Django==5.0.1
+django-cors-headers==4.9.0
 django-filter==25.1
 django-lti==0.7.1
 django-redis==5.4.0


### PR DESCRIPTION
Requires #259 to be merged first. The diff will include the commits to that branch until then.

- Moves most security configurations to a new `security.py` file.
- Correctly configures `ALLOWED_HOSTS` and `SECRET_KEY` from hard-coded dev values.
- Adds `CSRF_TRUSTED_ORIGINS` to only include the BASE_URL by default.
- Adds `django-cors-headers` package and associated middleware.
- Adds `CORS_ALLOWED_ORIGINS` configuration, which only includes the BASE_URL by default.
- Relaxes the COOP security header posture slightly by updating `SECURE_CROSS_ORIGIN_OPENER_POLICY` to `"same-origin-allow-popups"`.

> [!IMPORTANT]
> Note that this PR requires you to destroy your python container **and image** and rebuild them, because of the additional pip package.