### PR TITLE
Sentry

### DIFF
--- a/app/materia/settings/base.py
+++ b/app/materia/settings/base.py
@@ -3,6 +3,10 @@
 import os
 from pathlib import Path
 
+import sentry_sdk
+from sentry_sdk.integrations.django import DjangoIntegration
+
+
 from core.utils.validator_util import ValidatorUtil
 
 from .apps import *  # noqa: F401, F403
@@ -192,3 +196,15 @@ EMAIL_SSL_CERTFILE = os.environ.get("EMAIL_SSL_CERTFILE")
 # Sendgrid config
 SENDGRID_API_KEY = os.environ.get("SENDGRID_API_KEY")
 SENDGRID_SANDBOX_MODE_IN_DEBUG = False
+
+# Sentry config
+SENTRY_DSN = os.environ.get("SENTRY_DSN")
+if SENTRY_DSN:
+    sentry_sdk.init(
+        dsn=SENTRY_DSN,
+        integrations=[DjangoIntegration()],
+        environment=os.environ.get("SENTRY_ENVIRONMENT", "development"),
+        send_default_pii=True,
+        # 0.1 is 10% of transactions sent to Sentry. can replace with `traces_sampler` later for more control
+        traces_sample_rate=0.1,
+    )

--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -18,6 +18,7 @@ python-dateutil==2.9.0
 pytz==2024.1
 PyYAML==6.0.1
 s3transfer==0.11.4
+sentry-sdk[django]~=2.50.0
 setuptools==69.0.3
 six==1.17.0
 sqlparse==0.4.4

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -133,3 +133,7 @@ SENDGRID_API_KEY=""
 #  redirect login attempts, set this to the desired URL to redirect to from
 #  "/login"
 AUTH_LOGIN_ROUTE_OVERRIDE=false
+
+# Sentry
+SENTRY_DSN=
+SENTRY_ENVIRONMENT=development


### PR DESCRIPTION
Add basic Sentry config.

Adds 2 settings to `.env` that will need to be added in Secrets Manager:

- `SENTRY_DSN` - available within Sentry itself
- `SENTRY_ENVIRONMENT` - `"development"` by default. recommend `"qa"`, `"prod"`, etc. for servers

There might be a better settings file to put this in, just let me know.

There's plenty of updates we can make to this after, but this initial config should work for now.