### PR TITLE
Storage Logs Save Endpoint

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -780,16 +780,6 @@ class UserExtraAttemptsSerializer(serializers.ModelSerializer):
 
 
 class PlayStorageSaveSerializer(serializers.Serializer):
-
-    class BodySerializer(serializers.Serializer):
-
-        class LogSerializer(serializers.Serializer):
-            name = serializers.CharField()
-            data = serializers.DictField()
-            queueId = serializers.CharField()
-
-        play_id = serializers.CharField()
-        logs = LogSerializer(many=True)
-    
-    body = BodySerializer()
+    play_id = serializers.CharField()
+    logs = serializers.JSONField()
 

--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -777,3 +777,19 @@ class UserExtraAttemptsSerializer(serializers.ModelSerializer):
     class Meta:
         model = UserExtraAttempts
         fields = "__all__"
+
+
+class PlayStorageSaveSerializer(serializers.Serializer):
+
+    class BodySerializer(serializers.Serializer):
+
+        class LogSerializer(serializers.Serializer):
+            name = serializers.CharField()
+            data = serializers.DictField()
+            queueId = serializers.CharField()
+
+        play_id = serializers.CharField()
+        logs = LogSerializer(many=True)
+    
+    body = BodySerializer()
+

--- a/app/api/urls/api_urls.py
+++ b/app/api/urls/api_urls.py
@@ -9,6 +9,7 @@ from api.views import (
     users,
     widget_instances,
     widgets,
+    logstorage
 )
 from api.views.lti import LtiWidgetInstancesInCourseView
 from django.urls import include, path
@@ -37,4 +38,5 @@ urlpatterns = [
     path("generate/qset/", generation.GenerateQsetView.as_view()),
     path("generate/from_prompt/", generation.GenerateFromPromptView.as_view()),
     path("lti/<slug:context_id>/instances/", LtiWidgetInstancesInCourseView.as_view()),
+    path("play_storage_data_save/", logstorage.PlayStorageSaveView.as_view()),
 ]

--- a/app/api/urls/api_urls.py
+++ b/app/api/urls/api_urls.py
@@ -38,5 +38,5 @@ urlpatterns = [
     path("generate/qset/", generation.GenerateQsetView.as_view()),
     path("generate/from_prompt/", generation.GenerateFromPromptView.as_view()),
     path("lti/<slug:context_id>/instances/", LtiWidgetInstancesInCourseView.as_view()),
-    path("play_storage_data_save/", logstorage.PlayStorageSaveView.as_view()),
+    path("storage/", logstorage.PlayStorageSaveView.as_view()),
 ]

--- a/app/api/views/logstorage.py
+++ b/app/api/views/logstorage.py
@@ -1,0 +1,56 @@
+import base64
+import json
+
+from core.models import LogPlay, LogStorage
+from core.message_exception import MsgNoLogin, MsgInvalidInput
+from core.utils.validator_util import ValidatorUtil
+
+from rest_framework import permissions
+from rest_framework.views import APIView
+from rest_framework.response import Response
+
+from api.serializers import PlayStorageSaveSerializer
+
+class PlayStorageSaveView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        serializer = PlayStorageSaveSerializer(data=request.data)
+        serializer.is_valid(raise_exception=True)
+
+        body_object = serializer.validated_data["body"]
+
+        play_id = body_object["play_id"]
+        log_data = body_object["logs"]
+
+        try:
+            play = LogPlay.objects.get(id=play_id)
+        except LogPlay.DoesNotExist:
+            return MsgInvalidInput(msg="No play found with the given Play ID")
+
+        user = request.user
+        instance = play.instance
+
+        if not instance.playable_by_current_user(user):
+            return MsgNoLogin(request=request)
+        
+        logs = []
+        
+        if ValidatorUtil.is_valid_hash(instance.id) and ValidatorUtil.is_valid_long_hash(play_id):
+            for storage_packet in log_data:
+                stringified_data = json.dumps(storage_packet.get("data"))
+                byte_data = stringified_data.encode("utf-8")
+                logs.append(
+                    LogStorage(
+                        instance=instance,
+                        play_log=play,
+                        user=user,
+                        name=storage_packet.get("name"),
+                        data=base64.b64encode(byte_data)
+                    )
+                )
+
+        LogStorage.objects.bulk_create(logs)
+
+        return Response(True)
+

--- a/app/api/views/logstorage.py
+++ b/app/api/views/logstorage.py
@@ -18,10 +18,8 @@ class PlayStorageSaveView(APIView):
         serializer = PlayStorageSaveSerializer(data=request.data)
         serializer.is_valid(raise_exception=True)
 
-        body_object = serializer.validated_data["body"]
-
-        play_id = body_object["play_id"]
-        log_data = body_object["logs"]
+        play_id = serializer.validated_data["play_id"]
+        log_data = serializer.validated_data["logs"]
 
         try:
             play = LogPlay.objects.get(id=play_id)

--- a/app/api/views/logstorage.py
+++ b/app/api/views/logstorage.py
@@ -37,14 +37,17 @@ class PlayStorageSaveView(APIView):
         if ValidatorUtil.is_valid_hash(instance.id) and ValidatorUtil.is_valid_long_hash(play_id):
             for storage_packet in log_data:
                 stringified_data = json.dumps(storage_packet.get("data"))
+
                 byte_data = stringified_data.encode("utf-8")
+                encoded = base64.b64encode(byte_data).decode("ascii")
+
                 logs.append(
                     LogStorage(
                         instance=instance,
                         play_log=play,
                         user=user,
                         name=storage_packet.get("name"),
-                        data=base64.b64encode(byte_data)
+                        data=encoded,
                     )
                 )
 

--- a/app/api/views/logstorage.py
+++ b/app/api/views/logstorage.py
@@ -13,6 +13,7 @@ from api.serializers import PlayStorageSaveSerializer
 
 class PlayStorageSaveView(APIView):
     permission_classes = [permissions.IsAuthenticated]
+    http_method_names = ["post"]
 
     def post(self, request):
         serializer = PlayStorageSaveSerializer(data=request.data)

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -391,7 +391,7 @@ export const apiSessionVerify = (play_id) => {
 export const apiSavePlayStorage = ({ play_id, logs }) => {
   return handleRequest(
     methods.POST,
-    '/api/play_storage_data_save/',
+    '/api/storage/',
     {
       "play_id": play_id,
       "logs": logs

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -388,9 +388,17 @@ export const apiSessionVerify = (play_id) => {
 	})
 }
 
-// TODO update or retire
 export const apiSavePlayStorage = ({ play_id, logs }) => {
-	return handleRequest(methods.POST, '/api/json/play_storage_data_save/', ({ body: `data=${formatFetchBody([play_id, logs])}` }))
+  return handleRequest(
+    methods.POST,
+    '/api/play_storage_data_save/',
+    {
+      body: {
+        "play_id": play_id,
+        "logs": logs
+      }
+    },
+  )
 }
 
 export const apiSavePlayLogs = ({ request }) => {

--- a/src/util/api.js
+++ b/src/util/api.js
@@ -393,10 +393,8 @@ export const apiSavePlayStorage = ({ play_id, logs }) => {
     methods.POST,
     '/api/play_storage_data_save/',
     {
-      body: {
-        "play_id": play_id,
-        "logs": logs
-      }
+      "play_id": play_id,
+      "logs": logs
     },
   )
 }


### PR DESCRIPTION
This pull request resolves the issue of LogStorage entries not being saved and retrieved due to the log storage CRUD endpoints not being present in the Django re-write.

Adds the save endpoint

`/api/play_storage_data_save`