### PR TITLE
Fixes individual-scores component requesting n-1 pages of logs

### DIFF
--- a/src/components/my-widgets-score-semester-individual.jsx
+++ b/src/components/my-widgets-score-semester-individual.jsx
@@ -68,7 +68,7 @@ const MyWidgetScoreSemesterIndividual = ({ semester, instId, contexts, setInvali
 	)
 
 	useEffect(() => {
-		if (page < data?.total_num_pages) { refetch() }
+		if (page <= data?.total_num_pages) { refetch() }
 		else setState({ ...state, isLoading: false })
 	}, [page])
 


### PR DESCRIPTION
Resolves #290. An easy way to test: temporarily update `page_size` in `PlaySessionPagination` in `app/api/views/playsessions.py` to a low number like 2 or 5, then visit the Individual Scores tab with at least two pages' worth of logs. You should see the correct number of individual requests to `/api/play-sessions/...` that match the total number of pages.