### PR TITLE
Fixes PlayIdSerializer Usage

### DIFF
--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -268,7 +268,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
             return Response(serializer.data)
 
         elif play_id is not None:
-            play_id_serializer = PlayIdSerializer(data=play_id)
+            play_id_serializer = PlayIdSerializer(data={"play_id": play_id})
             if play_id_serializer.is_valid(raise_exception=True):
                 qset = instance.get_qset_for_play(play_id)
                 serializer = QuestionSetSerializer(qset)


### PR DESCRIPTION
## Problem
The `question_sets` endpoint passes a string to `PlayIdSerializer`, but the serializer expects a dictionary with a `play_id` key, resulting in a validation error.

## Solution
Wrap the `play_id` value in a dictionary when instantiating the serializer