### PR TITLE
CDN URL used for asset rendering + Generating thumbnails while uploading assets

### DIFF
--- a/app/core/utils/media_util.py
+++ b/app/core/utils/media_util.py
@@ -1,21 +1,6 @@
 from django.conf import settings
-from core.utils.context_util import ContextUtil
 
-
-class MediaUtil:
-    @staticmethod
-    def create(request) -> dict:
-        context = ContextUtil.create(
-            title="Media Catalog",
-            js_resources=settings.JS_GROUPS["media"],
-            css_resources=settings.CSS_GROUPS["media"],
-            request=request,
-            js_globals={
-                "MEDIA_URL": settings.URLS["MEDIA_URL"],
-                "MEDIA_UPLOAD_URL": settings.URLS["MEDIA_UPLOAD_URL"],
-                "USE_CDN": settings.DRIVER_SETTINGS['s3']['use_cdn'], # Boolean to see if frontend should use CDN URL
-                "CDN_URL": settings.DRIVER_SETTINGS['s3']['cdn_domain'], # CDN URL being passed in
-            },
-        )
-
-        return context
+media_urls = {
+    "USE_CDN": settings.DRIVER_SETTINGS['s3']['use_cdn'], # Boolean to see if frontend should use CDN URL
+    "CDN_URL": settings.DRIVER_SETTINGS['s3']['cdn_domain'], # CDN URL being passed in
+}

--- a/app/core/utils/media_util.py
+++ b/app/core/utils/media_util.py
@@ -1,0 +1,21 @@
+from django.conf import settings
+from core.utils.context_util import ContextUtil
+
+
+class MediaUtil:
+    @staticmethod
+    def create(request) -> dict:
+        context = ContextUtil.create(
+            title="Media Catalog",
+            js_resources=settings.JS_GROUPS["media"],
+            css_resources=settings.CSS_GROUPS["media"],
+            request=request,
+            js_globals={
+                "MEDIA_URL": settings.URLS["MEDIA_URL"],
+                "MEDIA_UPLOAD_URL": settings.URLS["MEDIA_UPLOAD_URL"],
+                "USE_CDN": settings.DRIVER_SETTINGS['s3']['use_cdn'], # Boolean to see if frontend should use CDN URL
+                "CDN_URL": settings.DRIVER_SETTINGS['s3']['cdn_domain'], # CDN URL being passed in
+            },
+        )
+
+        return context

--- a/app/core/views/media.py
+++ b/app/core/views/media.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
 from django.core.validators import FileExtensionValidator
-from django.http import HttpResponseNotFound, JsonResponse
+from django.http import HttpResponseNotFound, JsonResponse, HttpResponseRedirect
 from django.shortcuts import render
 from django.views.generic import TemplateView
 
@@ -34,13 +34,19 @@ class MediaImportView(TemplateView):
 
 class MediaRender:
     def index(request, asset_id, size="original"):
-        try:
-            asset = Asset.objects.get(id=asset_id)
-            return asset.render(size)
-        except Asset.DoesNotExist:
-            logger.error(f"Asset: {asset_id} not found")
-            return HttpResponseNotFound()
-
+        # If we are using the CDN URL, directly render the media using the CDN URL
+        if(settings.DRIVER_SETTINGS['s3']['use_cdn']):
+            base_cdn_url = settings.DRIVER_SETTINGS['s3']['cdn_domain']
+            redirect_url = f"{base_cdn_url}{asset_id}_{size}"
+            return HttpResponseRedirect(redirect_url)
+        else: # Otherwise try to render the asset using S3
+            try:
+                asset = Asset.objects.get(id=asset_id)
+                return asset.render(size)
+            except Asset.DoesNotExist:
+                logger.error(f"Asset: {asset_id} not found")
+                return HttpResponseNotFound()
+        
 
 class MediaUpload:
     @login_required

--- a/app/core/views/media.py
+++ b/app/core/views/media.py
@@ -4,6 +4,7 @@ from time import gmtime, strftime
 from core.models import Asset
 from core.services.asset_service import AssetService
 from core.utils.context_util import ContextUtil
+from core.utils.media_util import MediaUtil
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
@@ -18,19 +19,7 @@ logger = logging.getLogger(__name__)
 class MediaImportView(TemplateView):
     @login_required
     def index(request):
-        context = ContextUtil.create(
-            title="Media Catalog",
-            js_resources=settings.JS_GROUPS["media"],
-            css_resources=settings.CSS_GROUPS["media"],
-            request=request,
-            js_globals={
-                "MEDIA_URL": settings.URLS["MEDIA_URL"],
-                "MEDIA_UPLOAD_URL": settings.URLS["MEDIA_UPLOAD_URL"],
-                "USE_CDN": settings.DRIVER_SETTINGS['s3']['use_cdn'], # Boolean to see if frontend should use CDN URL
-                "CDN_URL": settings.DRIVER_SETTINGS['s3']['cdn_domain'], # CDN URL being passed in
-            },
-        )
-
+        context = MediaUtil.create(request)
         return render(request, "react.html", context)
 
 

--- a/app/core/views/media.py
+++ b/app/core/views/media.py
@@ -26,12 +26,11 @@ class MediaImportView(TemplateView):
             js_globals={
                 "MEDIA_URL": settings.URLS["MEDIA_URL"],
                 "MEDIA_UPLOAD_URL": settings.URLS["MEDIA_UPLOAD_URL"],
-                "USE_CDN": settings.DRIVER_SETTINGS['s3']['use_cdn'],
-                "CDN_URL": settings.DRIVER_SETTINGS['s3']['cdn_domain'],
+                "USE_CDN": settings.DRIVER_SETTINGS['s3']['use_cdn'], # Boolean to see if frontend should use CDN URL
+                "CDN_URL": settings.DRIVER_SETTINGS['s3']['cdn_domain'], # CDN URL being passed in
             },
         )
 
-        print(context)
         return render(request, "react.html", context)
 
 

--- a/app/core/views/media.py
+++ b/app/core/views/media.py
@@ -27,7 +27,8 @@ class MediaImportView(TemplateView):
             js_globals={
                 "MEDIA_URL": settings.URLS["MEDIA_URL"],
                 "MEDIA_UPLOAD_URL": settings.URLS["MEDIA_UPLOAD_URL"],
-            } | media_urls, # Concatante the main media URLs + the addiotnal URLs/properties
+            } 
+            | media_urls, # Concatante the main media URLs + the addiotnal URLs/properties
         )
         return render(request, "react.html", context)
 
@@ -35,7 +36,7 @@ class MediaImportView(TemplateView):
 class MediaRender:
     def index(request, asset_id, size="original"):
         # If we are using the CDN URL, directly render the media using the CDN URL
-        if(settings.DRIVER_SETTINGS['s3']['use_cdn']):
+        if settings.DRIVER_SETTINGS['s3']['use_cdn']:
             base_cdn_url = settings.DRIVER_SETTINGS['s3']['cdn_domain']
             redirect_url = f"{base_cdn_url}{asset_id}_{size}"
             return HttpResponseRedirect(redirect_url)
@@ -44,7 +45,7 @@ class MediaRender:
                 asset = Asset.objects.get(id=asset_id)
                 return asset.render(size)
             except Asset.DoesNotExist:
-                logger.error(f"Asset: {asset_id} not found")
+                logger.error("Asset: %s not found", asset_id)
                 return HttpResponseNotFound()
         
 

--- a/app/core/views/media.py
+++ b/app/core/views/media.py
@@ -4,7 +4,7 @@ from time import gmtime, strftime
 from core.models import Asset
 from core.services.asset_service import AssetService
 from core.utils.context_util import ContextUtil
-from core.utils.media_util import MediaUtil
+from core.utils.media_util import media_urls
 from django.conf import settings
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import ValidationError
@@ -19,7 +19,16 @@ logger = logging.getLogger(__name__)
 class MediaImportView(TemplateView):
     @login_required
     def index(request):
-        context = MediaUtil.create(request)
+        context = ContextUtil.create(
+            title="Media Catalog",
+            js_resources=settings.JS_GROUPS["media"],
+            css_resources=settings.CSS_GROUPS["media"],
+            request=request,
+            js_globals={
+                "MEDIA_URL": settings.URLS["MEDIA_URL"],
+                "MEDIA_UPLOAD_URL": settings.URLS["MEDIA_UPLOAD_URL"],
+            } | media_urls, # Concatante the main media URLs + the addiotnal URLs/properties
+        )
         return render(request, "react.html", context)
 
 

--- a/app/core/views/media.py
+++ b/app/core/views/media.py
@@ -26,7 +26,8 @@ class MediaImportView(TemplateView):
             js_globals={
                 "MEDIA_URL": settings.URLS["MEDIA_URL"],
                 "MEDIA_UPLOAD_URL": settings.URLS["MEDIA_UPLOAD_URL"],
-                "CDN_URL": settings.URLS["CDN_URL"],
+                "USE_CDN": settings.DRIVER_SETTINGS['s3']['use_cdn'],
+                "CDN_URL": settings.DRIVER_SETTINGS['s3']['cdn_domain'],
             },
         )
 

--- a/app/core/views/media.py
+++ b/app/core/views/media.py
@@ -26,9 +26,11 @@ class MediaImportView(TemplateView):
             js_globals={
                 "MEDIA_URL": settings.URLS["MEDIA_URL"],
                 "MEDIA_UPLOAD_URL": settings.URLS["MEDIA_UPLOAD_URL"],
+                "CDN_URL": settings.URLS["CDN_URL"],
             },
         )
 
+        print(context)
         return render(request, "react.html", context)
 
 

--- a/app/materia/settings/urls.py
+++ b/app/materia/settings/urls.py
@@ -62,4 +62,10 @@ URLS = {
             "http://localhost/",
         )
     ),
+    "CDN_URL": enforce_trailing_slash(
+        os.environ.get(
+            "ASSET_STORAGE_S3_CDN_DOMAIN",
+            "http://localhost/cdn/",
+        )
+    ),
 }

--- a/app/materia/settings/urls.py
+++ b/app/materia/settings/urls.py
@@ -62,10 +62,4 @@ URLS = {
             "http://localhost/",
         )
     ),
-    "CDN_URL": enforce_trailing_slash(
-        os.environ.get(
-            "ASSET_STORAGE_S3_CDN_DOMAIN",
-            "http://localhost/cdn/",
-        )
-    ),
 }

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -303,8 +303,7 @@ class S3AssetStorageDriver:
                 ExtraArgs={"ContentType": asset.get_mime_type()},
             )
         except Exception as e:
-            logger.info("Error saving thumbnail to S3")
-            logger.info(e)
+            logger.error("Error saving thumbnail to S3", exc_info=True,)
         
 
     def migrate_to(driver, cleanup_delete=False):

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -125,12 +125,21 @@ class S3AssetStorageDriver:
     def handle_uploaded_file(asset, uploaded_file):
         s3_client = S3AssetStorageDriver.get_s3(True)
         uploaded_file.seek(0)
+
+        # Need to use a file buffer in order to access the original file again after uploading to S3 
+        file_bytes = uploaded_file.read()
+        file_buffer = io.BytesIO(file_bytes)
+
+        file_buffer.seek(0)
         s3_client.upload_fileobj(
-            Fileobj=uploaded_file,
+            Fileobj=file_buffer,
             Bucket=settings.DRIVER_SETTINGS["s3"]["bucket"],
             Key=S3AssetStorageDriver.get_key_name(asset.id, "original"),
             ExtraArgs={"ContentType": asset.get_mime_type()},
         )
+        # Upload the thumbnail
+        thumbnail_buffer = io.BytesIO(file_bytes)
+        S3AssetStorageDriver.build_size_thumbnail(asset, thumbnail_buffer)
 
     def render(asset, size):
         from django.http import HttpResponseNotFound
@@ -240,6 +249,62 @@ class S3AssetStorageDriver:
             os.remove(temporary_file.name)
             logger.info("Error saving new size to S3")
             logger.info(e)
+
+    # Function for building the thumbnail for the uploaded image
+    # Assumes the asset is an image AND use the default thumbnail size
+    def build_size_thumbnail(asset, uploaded_file):
+        from PIL import Image
+
+        target_size = 75
+        uploaded_file.seek(0)
+        img = Image.open(uploaded_file)
+
+        new_size = (0, 0)
+        # if the image is wider than it is tall, constrain height
+        original_width, original_height = img.size
+        if original_width > original_height:
+            new_size = (
+                int(target_size * original_width / original_height),
+                target_size,
+            )
+        # otherwise constrain width
+        else:
+            new_size = (
+                target_size,
+                int(target_size * original_height / original_width),
+            )
+
+        img = img.resize(new_size, Image.LANCZOS)
+
+        ## No need to check for crop
+        new_width, new_height = img.size
+        crop_dimensions = (
+            (new_width - target_size) / 2,
+            (new_height - target_size) / 2,
+            (new_width + target_size) / 2,
+            (new_height + target_size) / 2,
+        )
+        img = img.crop(crop_dimensions)
+        
+        new_file_format = asset.file_type.upper()
+        # Pillow does not recognize 'JPG' as a valid file format
+        if new_file_format == "JPG":
+            new_file_format = "JPEG"
+        
+        new_bytes = io.BytesIO()
+        img.save(new_bytes, format=new_file_format)
+        new_bytes.seek(0)
+
+        s3 = S3AssetStorageDriver.get_s3()
+        bucket = settings.DRIVER_SETTINGS["s3"]["bucket"]
+        new_key = S3AssetStorageDriver.get_key_name(asset.id, "thumbnail")
+
+        put_data = {
+            "Body": new_bytes.getvalue(),
+            "ContentType": asset.get_mime_type(),
+            "ContentLength": new_bytes.getbuffer().nbytes,
+        }
+        s3.Object(bucket, new_key).put(**put_data)
 
     def migrate_to(driver, cleanup_delete=False):
         if driver == "file":

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -139,7 +139,7 @@ class S3AssetStorageDriver:
         )
         # Upload the thumbnail
         thumbnail_buffer = io.BytesIO(file_bytes)
-        S3AssetStorageDriver.build_size_thumbnail(asset, thumbnail_buffer)
+        S3AssetStorageDriver.build_size_thumbnail(asset, thumbnail_buffer, s3_client)
 
     def render(asset, size):
         from django.http import HttpResponseNotFound
@@ -252,7 +252,7 @@ class S3AssetStorageDriver:
 
     # Function for building the thumbnail for the uploaded image
     # Assumes the asset is an image AND use the default thumbnail size
-    def build_size_thumbnail(asset, uploaded_file):
+    def build_size_thumbnail(asset, uploaded_file, client):
         from PIL import Image
 
         target_size = 75
@@ -295,16 +295,17 @@ class S3AssetStorageDriver:
         img.save(new_bytes, format=new_file_format)
         new_bytes.seek(0)
 
-        s3 = S3AssetStorageDriver.get_s3()
-        bucket = settings.DRIVER_SETTINGS["s3"]["bucket"]
-        new_key = S3AssetStorageDriver.get_key_name(asset.id, "thumbnail")
-
-        put_data = {
-            "Body": new_bytes.getvalue(),
-            "ContentType": asset.get_mime_type(),
-            "ContentLength": new_bytes.getbuffer().nbytes,
-        }
-        s3.Object(bucket, new_key).put(**put_data)
+        try:
+            client.upload_fileobj(
+                Fileobj=new_bytes,
+                Bucket=settings.DRIVER_SETTINGS["s3"]["bucket"],
+                Key=S3AssetStorageDriver.get_key_name(asset.id, "thumbnail"),
+                ExtraArgs={"ContentType": asset.get_mime_type()},
+            )
+        except Exception as e:
+            logger.info("Error saving thumbnail to S3")
+            logger.info(e)
+        
 
     def migrate_to(driver, cleanup_delete=False):
         if driver == "file":

--- a/src/components/media-importer.jsx
+++ b/src/components/media-importer.jsx
@@ -147,7 +147,7 @@ const MediaImporter = () => {
 				if (window.USE_CDN && window.CDN_URL){
 					return `${window.CDN_URL}/${data}_thumbnail`
 				}
-				return `${MEDIA_URL}${data}/thumbnail`
+				return `${window.MEDIA_URL}${data}/thumbnail`
 
 			case 'mp3': // intentional case fall-through
 			case 'wav': // intentional case fall-through

--- a/src/components/media-importer.jsx
+++ b/src/components/media-importer.jsx
@@ -144,8 +144,8 @@ const MediaImporter = () => {
 			case 'jpeg': // intentional case fall-through
 			case 'png': // intentional case fall-through
 			case 'gif': // intentional case fall-through
-				if (USE_CDN && CDN_URL){
-					return `${CDN_URL}/${data}_thumbnail`
+				if (window.USE_CDN && window.CDN_URL){
+					return `${window.CDN_URL}/${data}_thumbnail`
 				}
 				return `${MEDIA_URL}${data}/thumbnail`
 

--- a/src/components/media-importer.jsx
+++ b/src/components/media-importer.jsx
@@ -144,6 +144,9 @@ const MediaImporter = () => {
 			case 'jpeg': // intentional case fall-through
 			case 'png': // intentional case fall-through
 			case 'gif': // intentional case fall-through
+				if (USE_CDN && CDN_URL){
+					return `${CDN_URL}/${data}_thumbnail`
+				}
 				return `${MEDIA_URL}${data}/thumbnail`
 
 			case 'mp3': // intentional case fall-through


### PR DESCRIPTION
### Summary

This PR addresses [Issue 297](https://github.com/ucfcdl/Materia/issues/297).  Media assets are now rendered using CDN URLs (if enabled) AND thumbnails of assets are generated when importing/uploading assets.

### Changes

#### Media Importer

The media importer now has 2 more JS globals in order to use CDN URLs. The media importer checks if Materia is using CDN using `USE_CDN` and ensures `CDN_URL` is not empty before generating a CDN URL in the frontend and using that as the asset source. 

The importer also now when saving to S3, it uploads a thumbnail to S3 of the asset. The thumbnail is generated by the function `build_size_thumbnail()` which is used in `s3.py`.

#### Widget + Scoring

The widget and scoring components use the `MEDIA_URL` to find their assets. This is called in each widget. So instead of changing the URL in each individual widget, when a widget makes a call to the backend, it first checks if the `ASSET_STORAGE_S3_USE_CDN` is set to true in the `.env`. If it is it just returns the CDN URL  with the unique asset id and size. Otherwise it builds and returns the file from S3 (the slower process)

### Testing

To test ensure that in your .env the following variables have a value:

```
ASSET_STORAGE_S3_USE_CDN=true
ASSET_STORAGE_S3_CDN_DOMAIN="CDN_DOMAIN"
```

Replace `CDN_DOMAIN` with the actual CDN Domain or use the FakeS3 endpoint. To ensure that CDN is actually being used, check logging within the following function found in `media.py`

```
def index(request, asset_id, size="original"):
        # If we are using the CDN URL, directly render the media using the CDN URL
        if(settings.DRIVER_SETTINGS['s3']['use_cdn']):
            base_cdn_url = settings.DRIVER_SETTINGS['s3']['cdn_domain']
            redirect_url = f"{base_cdn_url}{asset_id}_{size}"
            return HttpResponseRedirect(redirect_url)
        else: # Otherwise try to render the asset using S3
            try:
                asset = Asset.objects.get(id=asset_id)
                return asset.render(size)
            except Asset.DoesNotExist:
                logger.error(f"Asset: {asset_id} not found")
                return HttpResponseNotFound()
```

To ensure that the original and thumbnail upload at the same time, ensure in the S3/FakeS3 files, both files are uploaded at the same time
