### PR TITLE
Logging Improvements

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -250,7 +250,7 @@ class WidgetSerializer(serializers.ModelSerializer):
                     f"Field not allowed to be modified: {field}"
                 )
 
-            logger.error(f"\nupdating widget field: {field}\n")
+            logger.info("updating widget field: %s", field)
             setattr(widget, field, value)
 
         if metadata_dict:
@@ -782,4 +782,3 @@ class UserExtraAttemptsSerializer(serializers.ModelSerializer):
 class PlayStorageSaveSerializer(serializers.Serializer):
     play_id = serializers.CharField()
     logs = serializers.JSONField()
-

--- a/app/api/views/logstorage.py
+++ b/app/api/views/logstorage.py
@@ -11,6 +11,7 @@ from rest_framework.response import Response
 
 from api.serializers import PlayStorageSaveSerializer
 
+
 class PlayStorageSaveView(APIView):
     permission_classes = [permissions.IsAuthenticated]
     http_method_names = ["post"]
@@ -32,9 +33,9 @@ class PlayStorageSaveView(APIView):
 
         if not instance.playable_by_current_user(user):
             return MsgNoLogin(request=request)
-        
+
         logs = []
-        
+
         if ValidatorUtil.is_valid_hash(instance.id) and ValidatorUtil.is_valid_long_hash(play_id):
             for storage_packet in log_data:
                 stringified_data = json.dumps(storage_packet.get("data"))
@@ -55,4 +56,3 @@ class PlayStorageSaveView(APIView):
         LogStorage.objects.bulk_create(logs)
 
         return Response(True)
-

--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -209,9 +209,10 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                         play.is_valid = False
                         play.save()
 
-                        tbString = traceback.format_exc()
                         logger.error(
-                            f"\nvalidation failure for play {play.id}:\n{tbString}"
+                            "validation failure for play %s",
+                            play.id,
+                            exc_info=True,
                         )
 
                         raise MsgFailure(msg="This play did not pass validation.")
@@ -262,38 +263,43 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                                         .submit()
                                     )
 
-                                    logger.error(
-                                        f"LTI-AGS: successfully transmitted "
-                                        f"completion for play {play.id}"
+                                    logger.info(
+                                        "LTI-AGS: successfully transmitted "
+                                        "completion for play %s",
+                                        play.id,
                                     )
 
                                 except AGSClaimNotDefined:
                                     logger.error(
-                                        f"LTI-AGS: AGS claim not defined "
-                                        f"for play {play.id}"
+                                        "LTI-AGS: AGS claim not defined for play %s",
+                                        play.id,
                                     )
                                 except AGSNoLineItem:
                                     logger.error(
-                                        f"LTI-AGS: no AGS operations performed; "
-                                        f"a line item was not provided for play {play.id}"
+                                        "LTI-AGS: no AGS operations performed; "
+                                        "a line item was not provided for play %s",
+                                        play.id,
                                     )
-                                except Exception as e:
+                                except Exception:
                                     logger.error(
-                                        f"LTI-AGS: failed to transmit completion "
-                                        f"for play {play.id}: {str(e)}"
+                                        "LTI-AGS: failed to transmit completion "
+                                        "for play %s",
+                                        play.id,
+                                        exc_info=True,
                                     )
                             else:
                                 if launch is None:
                                     logger.error(
-                                        f"LTI-AGS: launch recovery failure: unable to "
-                                        f"retrieve launch for play {play.id}"
+                                        "LTI-AGS: launch recovery failure: unable to "
+                                        "retrieve launch for play %s",
+                                        play.id,
                                     )
                                 else:
                                     logger.error(
-                                        f"LTI-AGS: no AGS operations performed; "
-                                        f"AGS scoring unavailable for play {play.id}"
+                                        "LTI-AGS: no AGS operations performed; "
+                                        "AGS scoring unavailable for play %s",
+                                        play.id,
                                     )
-                                pass
                 else:
                     preview_play_id = update_serializer.validated_data[
                         "preview_play_id"
@@ -307,9 +313,7 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                 return Response({"status": status.HTTP_200_OK, "success": True})
 
             except Exception:
-                logger.error("play session log save failure:")
-                tbString = traceback.format_exc()
-                logger.error(f"\ntraceback: {tbString}")
+                logger.error("play session log save failure", exc_info=True)
                 raise MsgFailure("Failed to Save", "Your play logs could not be saved.")
 
     def destroy(self, request):

--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -1,5 +1,4 @@
 import logging
-import traceback
 
 from api.filters import LogPlayFilterBackend
 from api.paginators import PageNumberWithTotalPagination

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -514,6 +514,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
 
             # If there was a refusal, return a message
             if len(refusals) > 0:
+                # TODO: evaluate logger level and details of `refusals`
                 logger.error(refusals)
                 raise MsgFailure(
                     msg=f"Could not update {len(refusals)} out of {len(updates)} permissions."
@@ -537,9 +538,8 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         try:
             duplicate = instance.duplicate(request.user, name, copy_existing_perms)
-        except Exception as e:
-            logger.error("Failed to copy widget instance:")
-            logger.error(e)
+        except Exception:
+            logger.error("Failed to copy widget instance", exc_info=True)
             raise MsgFailure(msg="Widget instance could not be copied.")
 
         return Response(WidgetInstanceSerializer(duplicate).data)

--- a/app/core/management/commands/populate_object_permissions.py
+++ b/app/core/management/commands/populate_object_permissions.py
@@ -35,8 +35,10 @@ class Command(base.BaseCommand):
             if not instance.permissions.exists():
                 if instance.user is not None:
                     logger.info(
-                        f"creating ObjectPermission record for user "
-                        f"{instance.user.id} for instance {instance.name}\n"
+                        "creating ObjectPermission record for user "
+                        "%s for instance %s",
+                        instance.user.id,
+                        instance.name,
                     )
                     instance.permissions.create(user=instance.user, permission="full")
 
@@ -49,8 +51,10 @@ class Command(base.BaseCommand):
             if not notification.permissions.exists():
                 if notification.to_id is not None:
                     logger.info(
-                        f"creating ObjectPermission record for user "
-                        f"{notification.to_id.id} for notification {notification.id}\n"
+                        "creating ObjectPermission record for user "
+                        "%s for notification %s",
+                        notification.to_id.id,
+                        notification.id,
                     )
                     notification.permissions.create(
                         user=notification.to_id, permission="full"

--- a/app/core/management/commands/populate_object_permissions.py
+++ b/app/core/management/commands/populate_object_permissions.py
@@ -22,8 +22,7 @@ class Command(base.BaseCommand):
 
         try:
             command_function(*kwargs["arguments"])
-        except Exception as e:
-            logger.info(e)
+        except Exception:
             logger.exception("")
 
     # utility command to back-populate ObjectPermission records based on instance ownership

--- a/app/core/management/commands/post-install.py
+++ b/app/core/management/commands/post-install.py
@@ -33,8 +33,7 @@ class Command(base.BaseCommand):
 
         try:
             command_function(*kwargs["arguments"])
-        except Exception as e:
-            logger.info(e)
+        except Exception:
             logger.exception("")
 
     def populate_db(self):

--- a/app/core/management/commands/storage.py
+++ b/app/core/management/commands/storage.py
@@ -21,8 +21,7 @@ class Command(base.BaseCommand):
         command_function = getattr(self, subcommand)
         try:
             command_function(*kwargs["arguments"])
-        except Exception as e:
-            logger.info(e)
+        except Exception:
             logger.exception("")
 
     def migrate_to_driver(self, *args):

--- a/app/core/management/commands/widget.py
+++ b/app/core/management/commands/widget.py
@@ -75,12 +75,12 @@ class Command(base.BaseCommand):
         file_name = os.path.basename(file_url)
         output_dir = WidgetInstallerService.get_temp_dir()
 
-        logger.info(f"Downloading .wigt package {file_url}")
+        logger.info("Downloading .wigt package %s", file_url)
         download_location = f"{output_dir}{file_name}"
         with request.urlopen(file_url) as download:
             open(download_location, "wb").write(download.read())
 
-        logger.info(f"Package downloaded: {download_location}")
+        logger.info("Package downloaded: %s", download_location)
         return download_location
 
     def validate_checksum(self, widget_path, checksum_path):
@@ -118,10 +118,12 @@ class Command(base.BaseCommand):
         if md5_hash != checksums["md5"]:
             raise Exception("Error: md5 checksum mismatch!")
 
-        logger.info("Checksum valid")
-        logger.info(f"Build date: {checksums['build_date']}")
-        logger.info(f"Git Source: {checksums['git']}")
-        logger.info(f"Git Commit: {checksums['git_version']}")
+        logger.info(
+            "Checksum valid\n" "Build date: %s\n" "Git Source: %s\n" "Git Commit: %s",
+            checksums["build_date"],
+            checksums["git"],
+            checksums["git_version"],
+        )
 
         return True
 
@@ -188,8 +190,11 @@ class Command(base.BaseCommand):
             return
         new_ver, wigt_url, checksum_url = result
 
-        logger.info(f"Currently installed version: {widget.version}")
-        logger.info(f"Latest available version: {new_ver}")
+        logger.info(
+            "Currently installed version: %s\nLatest available version: %s",
+            widget.version,
+            new_ver,
+        )
 
         # Check if an update is even needed
         update_needed = WidgetInstallerService.needs_update(widget_id, new_ver)

--- a/app/core/management/commands/widget.py
+++ b/app/core/management/commands/widget.py
@@ -32,8 +32,7 @@ class Command(base.BaseCommand):
         command_function = getattr(self, subcommand)
         try:
             command_function(*kwargs["arguments"])
-        except Exception as e:
-            logger.info(e)
+        except Exception:
             logger.exception("")
 
     def install_from_config(self, *args):
@@ -69,7 +68,7 @@ class Command(base.BaseCommand):
 
         if desired_id is not None:
             self.replace_id = desired_id
-            
+
         self.install(local_package)
 
     def download_package(self, file_url):
@@ -174,17 +173,18 @@ class Command(base.BaseCommand):
         # Get current version
         widget = Widget.objects.filter(id=widget_id).first()
         if widget is None:
-            logger.error(f"Widget with ID '{widget_id}' does not exist")
-            logger.error("Unable to update.")
+            logger.error(
+                "Widget with ID '%s' does not exist\nUnable to update.",
+                widget_id,
+            )
             return
 
         # Get latest version available
         logger.warning("Getting latest available version...")
         try:
             result = WidgetInstallerService.get_latest_version_for(widget_id)
-        except MsgException as e:
-            logger.error(e.msg)
-            logger.error("Unable to update.")
+        except MsgException:
+            logger.error("Unable to update.", exc_info=True)
             return
         new_ver, wigt_url, checksum_url = result
 

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -153,11 +153,11 @@ class Asset(models.Model):
 
             return True
 
-        except Exception as e:
+        except Exception:
             logger.error(
-                "The following exception occurred while attempting to store an asset:"
+                "The following exception occurred while attempting to store an asset",
+                exc_info=True,
             )
-            logger.error(e)
             return False
 
     def delete(self, *args, **kwargs) -> bool:
@@ -176,11 +176,11 @@ class Asset(models.Model):
             self = Asset()
             return True
 
-        except Exception as e:
+        except Exception:
             logger.error(
-                "The following exception occurred while attempting to remove an asset:"
+                "The following exception occurred while attempting to remove an asset",
+                exc_info=True,
             )
-            logger.error(e)
             return False
 
     def render(self, size="original"):
@@ -970,9 +970,11 @@ class Widget(models.Model):
         exporter_mappings = getattr(script_globals, "mappings", None)
         if exporter_mappings is None:
             logger.error(
-                f"Play data exporter for widget '{self.name}' ({self.id}) is invalid!"
+                "Play data exporter for widget '%s' (%s) is invalid!"
+                "\n - Missing top level dict object named 'mappings'.",
+                self.name,
+                self.id,
             )
-            logger.error(" - Missing top level dict object named 'mappings'.")
             raise MsgFailure(
                 msg="Play data exporter script is invalid; missing 'mappings' dict"
             )

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1158,7 +1158,7 @@ class WidgetInstance(models.Model):
                     super().save(*args, **kwargs)
                     success = True
                 except DatabaseError as e:
-                    logger.info(e)
+                    logger.info(e, exc_info=True)
                     # try again until the retries run out
 
         # UPDATING AN EXISTING INSTANCE

--- a/app/core/services/asset_service.py
+++ b/app/core/services/asset_service.py
@@ -49,10 +49,9 @@ class AssetService:
                 if user:
                     pass
                 return asset
-            except Exception as e:
-                logger.info("ASSET STORAGE ERROR")
-                logger.info(e)
-                pass
+            except Exception:
+                # TODO: consider if .error() might be more appropriate
+                logger.info("ASSET STORAGE ERROR", exc_info=True)
 
             # something failed in the above block, remove the asset
             asset.delete()

--- a/app/core/services/generator_service.py
+++ b/app/core/services/generator_service.py
@@ -170,8 +170,8 @@ class GenerationUtil:
                 f"- Widget: {widget.name}\n"
                 f"- Date: {datetime.now()}\n"
                 f"- Time to complete (seconds): {time_elapsed_seconds}\n"
-                f"- Number of questions asked to generate: {num_questions}\n"
-                f"- Error: {e}"
+                f"- Number of questions asked to generate: {num_questions}",
+                exc_info=True,
             )
             raise e
 
@@ -211,9 +211,9 @@ class GenerationUtil:
             result = GenerationUtil._query(prompt, "text")
         except MsgException as e:
             logger.error(
-                f"GENERATION UTIL: Error while generation prompt:\n"
-                f"- Prompt: {prompt}\n"
-                f"- Exception: {e}"
+                "GENERATION UTIL: Error while generation prompt:\n - Prompt: %s",
+                prompt,
+                exc_info=True,
             )
             raise e
 
@@ -251,24 +251,25 @@ class GenerationUtil:
                 top_p=1,
                 response_format=response_format,
             )
-        except OpenAIError as e:
+        except OpenAIError:
             logger.error(
-                "GENERATION ERROR: Client threw an error while attempting completion. Exception follows:"
+                "GENERATION ERROR: Client threw an error while attempting completion.",
+                exc_info=True,
             )
-            logger.error(e)
             raise MsgFailure(msg="Client threw an error while attempting completion")
-        except Exception as e:
+        except Exception:
             logger.error(
-                "GENERATION ERROR: Unknown error occurred while attempting completion. Exception follows:"
+                "GENERATION ERROR: Unknown error occurred while attempting completion.",
+                exc_info=True,
             )
-            logger.error(e)
             raise MsgFailure(msg="Unknown error occurred while attempting completion")
 
         # Check for refusal
         message = completion.choices[0].message
         if message.refusal is not None:
             logger.error(
-                f"GENERATION ERROR: Provider actively refused to run completion. Reason given: '{message.refusal}'"
+                "GENERATION ERROR: Provider actively refused to run completion. Reason given: '%s'",
+                message.refusal,
             )
             raise MsgFailure(msg="Provider actively refused to run completion")
 
@@ -310,11 +311,11 @@ class GenerationUtil:
                     api_key=api_key,
                     base_url=endpoint + "openai/v1",
                 )
-            except Exception as e:
+            except Exception:
                 logger.error(
-                    "GENERATION ERROR: Failed to initialize Azure OpenAI client:"
+                    "GENERATION ERROR: Failed to initialize Azure OpenAI client",
+                    exc_info=True,
                 )
-                logger.error(e)
 
         # OPENAI
         elif settings.AI_GENERATION["PROVIDER"] == "openai":
@@ -329,9 +330,11 @@ class GenerationUtil:
 
             try:
                 client = OpenAI(api_key=api_key)
-            except Exception as e:
-                logger.error("GENERATION ERROR: Failed to initialize OpenAI client:")
-                logger.error(e)
+            except Exception:
+                logger.error(
+                    "GENERATION ERROR: Failed to initialize OpenAI client",
+                    exc_info=True,
+                )
 
         # NOT A SUPPORTED PROVIDER
         else:

--- a/app/core/services/generator_service.py
+++ b/app/core/services/generator_service.py
@@ -178,7 +178,7 @@ class GenerationUtil:
         # A qset was received - decode it
         content = result.choices[0].message.content
         qset = json.loads(content)
-        logger.info(f"Generated question set received: {qset}")
+        logger.info("Generated question set received: %s", qset)
 
         # Log
         if settings.AI_GENERATION["LOG_STATS"]:

--- a/app/core/services/play_data_exporter_service.py
+++ b/app/core/services/play_data_exporter_service.py
@@ -70,11 +70,13 @@ class PlayDataExporterService:
 
                         # All is good, return results
                         return result, file_ext
-                    except Exception as e:
+                    except Exception:
                         logger.error(
-                            f"Playdata exporter '{export_type}' for widget {instance.widget.clean_name} failed to run:"
+                            "Playdata exporter '%s' for widget %s failed to run",
+                            export_type,
+                            instance.widget.clean_name,
+                            exc_info=True,
                         )
-                        logger.error(e)
                         raise MsgFailure(
                             msg="The playdata exporter failed to run", status=500
                         )

--- a/app/core/services/widget_installer_service.py
+++ b/app/core/services/widget_installer_service.py
@@ -482,8 +482,7 @@ class WidgetInstallerService:
                 widget_obj.save()
             # TODO: narrow down which kind(s) of Exception we should expect here
             except Exception:
-                # TODO: consider changing this to logger.error
-                logger.info(
+                logger.error(
                     "Exception when updating existing widget params", exc_info=True
                 )
                 raise Exception(f"Failure updating existing widget data: {widget_id}")
@@ -495,8 +494,7 @@ class WidgetInstallerService:
                 widget_id = widget_obj.id
             # TODO: narrow down which kind(s) of Exception we should expect here
             except Exception:
-                # TODO: consider changing this to logger.error
-                logger.info("Exception when saving widget params", exc_info=True)
+                logger.error("Exception when saving widget params", exc_info=True)
                 raise Exception(f"Failure creating new widget: {widget_id}")
 
         return widget_id

--- a/app/core/services/widget_installer_service.py
+++ b/app/core/services/widget_installer_service.py
@@ -538,9 +538,8 @@ class WidgetInstallerService:
                 try:
                     widget_instance.save()
                     qset.save()
-                except Exception as e:
-                    logger.error("Error updating demo instance:")
-                    logger.error(e)
+                except Exception:
+                    logger.error("Error updating demo instance", exc_info=True)
             else:
                 # new instance, nothing to upgrade
                 widget = Widget.objects.filter(pk=widget_id).first()
@@ -562,9 +561,8 @@ class WidgetInstallerService:
                 try:
                     widget_instance.save()
                     qset.save()
-                except Exception as e:
-                    logger.error("Error saving new demo instance:")
-                    logger.error(e)
+                except Exception:
+                    logger.error("Error saving new demo instance", exc_info=True)
 
             # TODO: this was originally a static output - may have to change this, maybe not?
             logger.info(f"Demo installed: {widget_instance.id}")

--- a/app/core/services/widget_installer_service.py
+++ b/app/core/services/widget_installer_service.py
@@ -127,7 +127,7 @@ class WidgetInstallerService:
                 existing_widget = Widget.objects.get(id=replace_id)
                 if "demo" in existing_widget.metadata:
                     existing_demo_inst_id = existing_widget.metadata["demo"]
-                    logger.info(f"Existing demo found: {existing_demo_inst_id}")
+                    logger.info("Existing demo found: %s", existing_demo_inst_id)
 
             except Widget.DoesNotExist:
                 pass
@@ -148,7 +148,7 @@ class WidgetInstallerService:
         # save metadata
         widget = Widget.objects.get(id=id)
 
-        logger.info(f"Widget installed: {dir}")
+        logger.info("Widget installed: %s", dir)
         success = True
         activity.item_id = id
         activity.value_1 = clean_name
@@ -213,7 +213,7 @@ class WidgetInstallerService:
             raise Exception("Unable to extract widget.")
         # assume it's a zip file, attempt to extract
         try:
-            logger.info(f"Extracting {file} to {extract_location}")
+            logger.info("Extracting %s to %s", file, extract_location)
             # TODO: zip extraction stuff
             with ZipFile(file) as archive:
                 archive.extractall(extract_location)
@@ -481,9 +481,11 @@ class WidgetInstallerService:
                     setattr(widget_obj, key, value)
                 widget_obj.save()
             # TODO: narrow down which kind(s) of Exception we should expect here
-            except Exception as e:
-                logger.info("Exception when updating existing widget params")
-                logger.info(e)
+            except Exception:
+                # TODO: consider changing this to logger.error
+                logger.info(
+                    "Exception when updating existing widget params", exc_info=True
+                )
                 raise Exception(f"Failure updating existing widget data: {widget_id}")
         except Widget.DoesNotExist:
             # new
@@ -492,9 +494,9 @@ class WidgetInstallerService:
                 widget_obj.save()
                 widget_id = widget_obj.id
             # TODO: narrow down which kind(s) of Exception we should expect here
-            except Exception as e:
-                logger.info("Exception when saving widget params")
-                logger.info(e)
+            except Exception:
+                # TODO: consider changing this to logger.error
+                logger.info("Exception when saving widget params", exc_info=True)
                 raise Exception(f"Failure creating new widget: {widget_id}")
 
         return widget_id
@@ -565,7 +567,7 @@ class WidgetInstallerService:
                     logger.error("Error saving new demo instance", exc_info=True)
 
             # TODO: this was originally a static output - may have to change this, maybe not?
-            logger.info(f"Demo installed: {widget_instance.id}")
+            logger.info("Demo installed: %s", widget_instance.id)
             return widget_instance.id
 
     def validate_demo(demo_data):
@@ -633,7 +635,7 @@ class WidgetInstallerService:
         if os.path.isdir(target_dir):
             shutil.rmtree(target_dir)
         shutil.copytree(source_path, target_dir)
-        logger.info(f"Widget files deployed: {widget_dir}")
+        logger.info("Widget files deployed %s", widget_dir)
 
     @staticmethod
     def uninstall_widget_files(id, clean_name):

--- a/app/core/utils/b64_util.py
+++ b/app/core/utils/b64_util.py
@@ -20,6 +20,6 @@ class Base64Util:
         try:
             decoded_bytes = base64.b64decode(data)
             return json.loads(decoded_bytes.decode("utf-8"))
-        except Exception as e:
-            logger.error(f"Error decoding JSON: {str(e)}")
+        except Exception:
+            logger.error("Error decoding JSON", exc_info=True)
             return {}

--- a/app/core/views/media.py
+++ b/app/core/views/media.py
@@ -38,7 +38,7 @@ class MediaRender:
             asset = Asset.objects.get(id=asset_id)
             return asset.render(size)
         except Asset.DoesNotExist:
-            logger.error(f"Asset: {asset_id} not found")
+            logger.error("Asset: %s not found", asset_id)
             return HttpResponseNotFound()
 
 

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -182,8 +182,11 @@ class WidgetPlayView(
             play.lti_token = lti_token
             play.save()
 
-            logger.error(
-                f"LTI: session initialization for user {play.user.id} with play {play.id} in context {play.context_id}"
+            logger.info(
+                "LTI: session initialization for user %s with play %s in context %s",
+                play.user.id,
+                play.id,
+                play.context_id,
             )
 
         return {"play_id": play.id, "lti_token": lti_token}
@@ -647,7 +650,7 @@ def _get_id_from_slug(widget_slug: str) -> int | None:
             pass
 
     logger.error(
-        f"Failed to get id from widget slug, likely an invalid slug: '{widget_slug}'"
+        "Failed to get id from widget slug, likely an invalid slug: '%s'", widget_slug
     )
     return None
 

--- a/app/lti/mixins.py
+++ b/app/lti/mixins.py
@@ -42,8 +42,10 @@ class LtiLaunchMixin:
             # raise an exception if current user does not match stored launch user
             if request.user.username != launch_username:
                 logger.error(
-                    f"LTI: ERROR: launch recovery username mismatch detected between "
-                    f"{request.user.username} and {launch_username}!"
+                    "LTI: ERROR: launch recovery username mismatch detected between "
+                    "%s and %s!",
+                    request.user.username,
+                    launch_username,
                 )
                 raise MsgFailure(msg="LTI Launch recovery authentication mismatch")
 

--- a/app/lti/services/auth.py
+++ b/app/lti/services/auth.py
@@ -49,7 +49,7 @@ class LTIAuthService:
 
         # user does not possess any of the roles recognized as instructor or student
         logger.error(
-            f"LTI auth: user does not have a known role or roles: {pformat(lti_roles)}"
+            "LTI auth: user does not have a known role or roles: %s}", lti_roles
         )
         return False
 
@@ -148,7 +148,7 @@ class LTIAuthService:
 
             return user
 
-        except Exception as e:
-            logger.error(f"LTI auth: exception!\n{pformat(e)}\n")
+        except Exception:
+            logger.error("LTI auth: exception!", exc_info=True)
             logout(request)
             return None

--- a/app/lti/services/auth.py
+++ b/app/lti/services/auth.py
@@ -1,5 +1,4 @@
 import logging
-from pprint import pformat
 
 # from core.models import Lti
 from django.conf import settings

--- a/app/lti/views/deep_linking.py
+++ b/app/lti/views/deep_linking.py
@@ -33,7 +33,8 @@ def lti_deep_link_selection(request):
             cached_launch_id = request.session["lti-deep-link"]
         except Exception:
             logger.error(
-                f"LTI: ERROR: cached launch ID could not be recovered for deep linking selection of inst: {selection}."
+                "LTI: ERROR: cached launch ID could not be recovered for deep linking selection of inst: %s.",
+                selection,
             )
             return error_page(request, "error_launch_recovery")
 
@@ -45,7 +46,7 @@ def lti_deep_link_selection(request):
 
     except Exception:
         logger.error(
-            f"LTI: ERROR: could not recover cached launch with ID {cached_launch_id}."
+            "LTI: ERROR: could not recover cached launch with ID %s.", cached_launch_id
         )
         return error_page(request, "error_launch_recovery")
 

--- a/app/scoring/module_factory.py
+++ b/app/scoring/module_factory.py
@@ -30,16 +30,14 @@ class ScoreModuleFactory:
 
             ScoreClass = cls._load_score_class(script_path, instance)
             if not ScoreClass:
-                logger.error(f"No score module found for widget {instance.widget.id}")
+                logger.error("No score module found for widget %s", instance.widget.id)
                 return None
 
             # Create and return an instance of the score module
             return ScoreClass(play=play)
 
-        except Exception as e:
-            import traceback
-
-            logger.error(f"Failed to load score module: {e}\n{traceback.format_exc()}")
+        except Exception:
+            logger.error("Failed to load score module", exc_info=True)
             return None
 
     @staticmethod
@@ -51,8 +49,8 @@ class ScoreModuleFactory:
             mod = types.ModuleType("temp_score_module")
             exec(code, mod.__dict__)
             return getattr(mod, instance.widget.score_module, None)
-        except Exception as e:
-            logger.error(f"Failed to load score module: {e}")
+        except Exception:
+            logger.error("Failed to load score module", exc_info=True)
             return None
 
     @classmethod

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -39,9 +39,12 @@ class DBAssetStorageDriver:
                 data_obj.created_at = timezone.now()
 
                 data_obj.save()
-        except Exception as e:
-            logger.error(f"Exception while storing asset data for asset {asset.id}")
-            logger.error(e)
+        except Exception:
+            logger.error(
+                "Exception while storing asset data for asset %s",
+                asset.id,
+                exc_info=True,
+            )
 
     def render(asset, size):
         from core.models import AssetData
@@ -62,7 +65,7 @@ class DBAssetStorageDriver:
                 asset_obj = AssetData.objects.get(id=asset.id, size=size)
                 asset_bytes = asset_obj.data
         except Exception as e:
-            logger.error(e)
+            logger.error(e, exc_info=True)
             return HttpResponseNotFound()
 
         asset_response = HttpResponse(asset_bytes)
@@ -92,9 +95,8 @@ class DBAssetStorageDriver:
             data_obj.created_at = timezone.now()
 
             data_obj.save()
-        except Exception as e:
-            logger.error("DB driver file upload error")
-            logger.error(e)
+        except Exception:
+            logger.error("DB driver file upload error", exc_info=True)
 
     # Build a specified size of an asset; either 'original', 'large', or 'thumbnail'
     def build_size(asset, size):

--- a/app/storage/file.py
+++ b/app/storage/file.py
@@ -39,7 +39,7 @@ class FileAssetStorageDriver:
             else:
                 asset_path = FileAssetStorageDriver.get_local_file_path(asset.id, size)
         except Exception as e:
-            logger.error(e)
+            logger.error(e, exc_info=True)
             return HttpResponseNotFound()
 
         if not os.path.isfile(asset_path):
@@ -152,7 +152,7 @@ class FileAssetStorageDriver:
                         os.remove(asset_full_path)
                 except Asset.DoesNotExist:
                     logger.error(
-                        f"File {asset_filename} has no corresponding Asset object"
+                        "File %s has no corresponding Asset object", asset_filename
                     )
                     continue
 
@@ -188,7 +188,7 @@ class FileAssetStorageDriver:
                         os.remove(asset_full_path)
                 except Asset.DoesNotExist:
                     logger.error(
-                        f"File {asset_filename} has no corresponding Asset object"
+                        "File %s has no corresponding Asset object", asset_filename
                     )
                     continue
         else:

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -233,7 +233,7 @@ class S3AssetStorageDriver:
             os.remove(temporary_file.name)
 
             return S3AssetStorageDriver.get_view_url(asset.id, size)
-        except Exception as e:
+        except Exception:
             os.remove(temporary_file.name)
             # TODO: consider changing this to logger.error
             logger.info("Error saving new size to S3", exc_info=True)

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -235,8 +235,7 @@ class S3AssetStorageDriver:
             return S3AssetStorageDriver.get_view_url(asset.id, size)
         except Exception:
             os.remove(temporary_file.name)
-            # TODO: consider changing this to logger.error
-            logger.info("Error saving new size to S3", exc_info=True)
+            logger.error("Error saving new size to S3", exc_info=True)
 
     def migrate_to(driver, cleanup_delete=False):
         if driver == "file":

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -235,8 +235,8 @@ class S3AssetStorageDriver:
             return S3AssetStorageDriver.get_view_url(asset.id, size)
         except Exception as e:
             os.remove(temporary_file.name)
-            logger.info("Error saving new size to S3")
-            logger.info(e)
+            # TODO: consider changing this to logger.error
+            logger.info("Error saving new size to S3", exc_info=True)
 
     def migrate_to(driver, cleanup_delete=False):
         if driver == "file":

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -67,9 +67,8 @@ class S3AssetStorageDriver:
                 raise Exception(
                     "S3: Failed to determine credential provider. Did you set the appropriate environment variable?"
                 )
-        except Exception as e:
-            logger.error("S3: Failed to create S3 session.")
-            logger.error(e)
+        except Exception:
+            logger.error("S3: Failed to create S3 session.", exc_info=True)
 
         s3_config = {}
         # Endpoint config is only required for fakeS3 - the param is not required for actual S3 on AWS
@@ -104,9 +103,8 @@ class S3AssetStorageDriver:
                 Key=key,
                 ExtraArgs={"ContentType": asset.get_mime_type()},
             )
-        except Exception as e:
-            logger.error(f"S3: Failed to store asset {key}")
-            logger.error(e)
+        except Exception:
+            logger.error("S3: Failed to store asset %s", key, exc_info=True)
 
     def exists(id, size):
         s3_resource = S3AssetStorageDriver.get_s3()
@@ -119,8 +117,7 @@ class S3AssetStorageDriver:
             if e.response["Error"]["Code"] == "404":
                 return False
             else:
-                logger.error("S3 exists check error")
-                logger.error(e)
+                logger.error("S3 exists check error", exc_info=True)
 
     def handle_uploaded_file(asset, uploaded_file):
         s3_client = S3AssetStorageDriver.get_s3(True)
@@ -149,7 +146,7 @@ class S3AssetStorageDriver:
             else:
                 asset_url = S3AssetStorageDriver.get_view_url(asset.id, size)
         except Exception as e:
-            logger.error(e)
+            logger.error(e, exc_info=True)
             return HttpResponseNotFound()
 
         return HttpResponseRedirect(asset_url)


### PR DESCRIPTION
Attempts to address (although probably not completely) #286.

**Please review each line of this thoroughly**, as my preferred logging style and assumptions may not 100% match your needs. Thankfully each section should be mostly self-contained.

Summary:

- Flagged level/detail concern w/ TODO _(please advise)_
  - app/api/views/widget_instances.py:517 
  - app/core/services/asset_service.py:54
  - app/core/services/widget_installer_service.py:486-488
  - app/core/services/widget_installer_service.py:499
  - app/storage/s3.py:239
- Updated a few particularly vocal `logger.error` instances to `.info`
  - app/api/serializers:253
  - app/api/views/playsessions.py:266-296
  - app/core/views/widget.py:185-189
- Converted various traceback formats to unified `exc_info=True`
  - I strongly recommend this over directly including the `Exception as e` and dealing with `format_exc`, unless you have specific use cases. Keeps things simple.
  - You'll mostly see this with `.error`, but it also works with the other levels
  - `.exception` basically is equivalent to `.error(exc_info=True)`, either is fine - the latter is more explicit.
- Converted log strings with variables from f-strings to logger's built-in string formatting.
  - I give my reasoning on a [comment on the main issue](https://github.com/ucfcdl/Materia/issues/286#issuecomment-3792404313), but in short it should help with Sentry categorization. That said, with the prod data in, Sentry is handling it more gracefully than I initially expected.
  - Normally readability of code is the main priority, but in this case readable logs are more important, IMO.
  - I left a few cases alone where the extra confusion probably doesn't outweigh the log separation. We can revisit those if they get annoying later.
  - If we really hate the `%s`, there might be other options. [Python's logging docs](https://docs.python.org/3/library/logging.html#logging.Logger.debug) says _"[...] you can use keywords in the format string, together with a single dictionary argument[...]"_ . Let me know if you'd like to investigate that.
- Combined some back-to-back logs into single logs
  - Ideally, a single problem should be in a single log where possible. Makes it easier to track stuff down, especially in Sentry.
- Removed excess `pass`
  - `pass` is a no-op and shouldn't be used outside of places it's absolutely required for structure.

Lemme know if I can clarify anything.