### PR TITLE
Miscellaneous Cleanup bugs and typo

### DIFF
--- a/app/api/serializers.py
+++ b/app/api/serializers.py
@@ -475,10 +475,11 @@ class PlaySessionCreateSerializer(serializers.Serializer):
 
     def validate(self, data):
         is_preview = data.get("is_preview", False)
-        instance = WidgetInstance.objects.get(pk=data["instanceId"])
-        if not instance:
+        try:
+            instance = WidgetInstance.objects.get(pk=data["instanceId"])
+        except WidgetInstance.DoesNotExist:
             raise serializers.ValidationError(
-                f"Instance ID {data["InstanceId"]} invalid."
+                f"Instance ID {data['instanceId']} invalid."
             )
 
         if not instance.playable_by_current_user(self.context["request"].user):

--- a/app/api/views/playsessions.py
+++ b/app/api/views/playsessions.py
@@ -312,7 +312,7 @@ class PlaySessionViewSet(viewsets.ModelViewSet):
                 logger.error(f"\ntraceback: {tbString}")
                 raise MsgFailure("Failed to Save", "Your play logs could not be saved.")
 
-    def destroy(self, request):
+    def destroy(self, request, pk=None):
         raise MethodNotAllowed("DELETE")
 
     @action(detail=True, methods=["get"])

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -116,7 +116,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
             ]
 
         # Anyone can play a widget and get its qset
-        elif self.action == "question_sets" or self.action == "retrieve":
+        elif self.action == "question_set" or self.action == "question_sets" or self.action == "retrieve":
             permission_classes = [AllowAny]
 
         # Catch all just to block anything else

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -578,9 +578,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
 
     @action(detail=True, methods=["post"])
     def undelete(self, request, pk=None):
-        instance = WidgetInstance.objects.get(id=pk)
-        if not instance:
-            return ValidationError("Must provide a valid instance ID.")
+        instance = self.get_object()
 
         if not instance.is_deleted:
             return ValidationError("Instance is not deleted.")

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -581,7 +581,7 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
 
         if not instance.is_deleted:
-            return ValidationError("Instance is not deleted.")
+            raise ValidationError("Instance is not deleted.")
 
         instance.is_deleted = False
         instance.save()

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -1171,7 +1171,7 @@ class WidgetInstance(models.Model):
         return qsets
 
     def duplicate(
-        self, owner: User, new_name: str, copy_exiting_perms: bool = False
+        self, owner: User, new_name: str, copy_existing_perms: bool = False
     ) -> Self:
         dupe = WidgetInstance.objects.get(pk=self.pk)
 
@@ -1211,7 +1211,7 @@ class WidgetInstance(models.Model):
         dupe_qset.save()
 
         # Copy perms, if requested
-        if copy_exiting_perms:
+        if copy_existing_perms:
             existing_perms = self.permissions.all()
             for existing_perm in existing_perms:
                 dupe.permissions.create(


### PR DESCRIPTION
  - question_set permissions: The question_set action (for fetching a specific qset by ID) was blocked for all users because it wasn't included in get_permissions(), causing it to fall through to the DenyAll default.
  - undelete action:
    - Used self.get_object() for consistency with other actions and to leverage DRF's built-in 404 handling. The "Must provide a valid instance ID" validation error is also never triggered as getting a non-existing widget instance ID returns 404
    - Changed return ValidationError to raise ValidationError. Returning an exception object instead of raising it caused a 500 error ("Expected a Response but received ValidationError")
  - Typo: updates copy_exiting_perms to copy_existing_perms
  - destroy action
    - missing pk parameter
  - PlaySessionSerializer: updates piece of code never reached, updates invalid InstanceId key