### PR TITLE
Reimplement Direct Media Upload

### DIFF
--- a/src/components/media-importer.jsx
+++ b/src/components/media-importer.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react'
+import React, {useState, useEffect, useRef, useCallback} from 'react'
 import { useQuery, useQueryClient } from 'react-query'
 import DragAndDrop from './drag-and-drop'
 import LoadingIcon from './loading-icon'
@@ -63,6 +63,27 @@ const MediaImporter = () => {
 	const [assetList, setAssetList] = useState({})
 	const [showDeletedAssets, setShowDeletedAssets] = useState(false)
 	const [filterSearch, setFilterSearch] = useState('') // Search bar filter
+
+	// Tell the creator that the media importer is ready to receive a direct upload file, if there is one
+	useEffect(() => {
+		parent.postMessage(JSON.stringify({ type: 'readyForDirectUpload', source: 'media-importer', data: '' }), '*')
+	}, [])
+
+	const postMessageHandler = useCallback((e) => {
+		const origin = `${e.origin}/`
+		if (origin !== window.STATIC_CROSSDOMAIN && origin !== window.BASE_URL) return
+		const file = new File(
+			[e.data.buffer],
+			e.data.name,
+			{ type: e.data.type, lastModified: e.data.lastModified }
+		)
+		_upload(file)
+	}, [])
+
+	useEffect(() => {
+		window.addEventListener('message', postMessageHandler)
+		return () => window.removeEventListener('message', postMessageHandler)
+	})
 
 	const { data: listOfAssets } = useQuery({
 		queryKey: ['media-assets', selectedAsset],

--- a/src/components/widget-creator.jsx
+++ b/src/components/widget-creator.jsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, {useState, useEffect, useRef, useCallback} from 'react';
 import { useQuery } from 'react-query'
 import LoadingIcon from './loading-icon';
 import { apiGetWidgetInstance, apiGetQuestionSet, apiCanBePublishedByCurrentUser, apiSaveWidget, apiGetWidgetLock, apiGetWidget, apiUserVerify, apiIsGenerable, apiWidgetPromptGenerate} from '../util/api'
@@ -216,17 +216,6 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		if (creatorState.lastSave) updateElapsed()
 	},[creatorState.lastSave])
 
-	// the listener is applied (and reapplied) when the widget is ready
-	useEffect(() => {
-		// setup the postmessage listener
-		window.addEventListener('message', onPostMessage, false)
-
-		// cleanup this listener
-		return () => {
-			window.removeEventListener('message', onPostMessage, false)
-		}
-	},[widgetReady])
-
 	useEffect(() => {
 		if (instance.id) {
 			instIdRef.current = instance.id
@@ -359,8 +348,13 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 	const onPostMessage = (e) => {
 		const origin = `${e.origin}/`
 		if (origin === window.STATIC_CROSSDOMAIN || origin === window.BASE_URL) {
-			if (typeof e.data !== 'string' || !e.data) return
-			const msg = JSON.parse(e.data)
+			if (!e.data) return
+			let msg = null
+			if (typeof e.data === 'string') {
+				msg = JSON.parse(e.data)
+			} else {
+				msg = e.data
+			}
 			switch (
 				msg.source // currently 'creator-core' || 'media-importer' - can be extended to other sources
 			) {
@@ -371,8 +365,19 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 						// if a file is pre-selected (by direct upload pipeline), go ahead and send it over
 						// this behavior only occurs for direct media uploads, bypassing user input
 						case 'readyForDirectUpload':
-							if (creatorState.directUploadMediaFile) return e.source.postMessage(creatorState.directUploadMediaFile, e.origin)
-							else return false
+							if (creatorState.directUploadMediaFile) {
+								setCreatorState({...creatorState, directUploadMediaFile: null})
+								return e.source.postMessage(
+									creatorState.directUploadMediaFile,
+									{
+										targetOrigin: e.origin,
+										transfer: [creatorState.directUploadMediaFile.buffer]
+									}
+								)
+							}
+							else {
+								return false
+							}
 						default:
 							return false
 					}
@@ -405,6 +410,17 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 
 		console.warn(`Unknown message from creator: ${origin}`)
 	}
+
+	// the listener is applied (and reapplied) when the widget is ready
+	useEffect(() => {
+		// setup the postmessage listener
+		window.addEventListener('message', onPostMessage, false)
+
+		// cleanup this listener
+		return () => {
+			window.removeEventListener('message', onPostMessage, false)
+		}
+	}, [widgetReady, onPostMessage])
 
 	const onCreatorReady = () => {
 		setWidgetReady(true)
@@ -635,7 +651,7 @@ const WidgetCreator = ({instId, widgetId, minHeight='', minWidth=''}) => {
 		setCreatorState({
 			...creatorState,
 			dialogPath: `${window.BASE_URL}media/import#${['jpg', 'gif', 'png', 'mp3'].join(',')}`,
-			directUploadMedia: media
+			directUploadMediaFile: media
 		})
 	}
 

--- a/src/materia/materia.creatorcore.js
+++ b/src/materia/materia.creatorcore.js
@@ -118,8 +118,20 @@ Namespace('Materia').CreatorCore = (() => {
 		_sendPostMessage('showMediaImporter', types)
 	}
 
-	const directUploadMedia = (mediaData) => {
-		_sendPostMessage('directUploadMedia', mediaData)
+	const directUploadMedia = (media) => {
+		media.arrayBuffer().then((buffer) => {
+			const data = {
+				buffer: buffer,
+				name: media.name,
+				type: media.type,
+				lastModified: media.lastModified
+			}
+
+			parent.postMessage({ type: 'directUploadMedia', source: 'creator-core', data: data }, {
+				targetOrigin: '*',
+				transfer: [data.buffer]
+			})
+		})
 	}
 
 	const save = (title, qset, version) => {


### PR DESCRIPTION
The Materia creator core has a function, `Materia.CreatorCore.directUploadMedia()`, which appears to allow creators to upload widgets directly from itself, instead of relying on the user using the media uploader interface. Though, it seems that this function at some point was broken. It makes a call out to Materia, though there is no code on Materia's end that catches that call or handles it.

This PR re-implements this functionality. This now allows creators to upload files themselves, which may allow for things like images that were proceduraly generated by the creator, or direct drag-and-drops of files onto the creator itself (instead of having to open the media interface first).

`.directUploadMedia()` takes in a `File` object.