### PR TITLE
Last second migration fixes part 2

### DIFF
--- a/app/core/management/commands/fake_current_db.py
+++ b/app/core/management/commands/fake_current_db.py
@@ -106,6 +106,10 @@ class Command(base.BaseCommand):
             "ALTER TABLE `date_range` DROP INDEX `semester_year_start_at_end_at`;"
         )
 
+        # Make the 'id' field of the lti table signed to match Django BigAutoField expectations
+        self.stdout.write("Making lti.id column signed")
+        cursor.execute("ALTER TABLE `lti` MODIFY `id` bigint SIGNED;")
+
         cursor.close()
 
         def convert_enum_to_varchar(table, column):

--- a/app/core/management/commands/fake_current_db.py
+++ b/app/core/management/commands/fake_current_db.py
@@ -108,7 +108,7 @@ class Command(base.BaseCommand):
 
         # Make the 'id' field of the lti table signed to match Django BigAutoField expectations
         self.stdout.write("Making lti.id column signed")
-        cursor.execute("ALTER TABLE `lti` MODIFY `id` bigint SIGNED;")
+        cursor.execute("ALTER TABLE `lti` MODIFY `id` bigint SIGNED AUTO_INCREMENT;")
 
         cursor.close()
 

--- a/app/core/migrations/0020_user_groups.py
+++ b/app/core/migrations/0020_user_groups.py
@@ -1,6 +1,7 @@
 from django.contrib.auth.models import Group
-from django.db import migrations
+from django.db import migrations, transaction
 from django.db.models import Q, Subquery
+from django.db.utils import IntegrityError
 
 
 def create_user_groups(apps, schema_editor):
@@ -76,9 +77,17 @@ def convert_user_groups(apps, schema_editor):
             django_user.is_superuser = True
             django_user.save()
         else:
-            UserGroups.objects.create(
-                user_id=user_id, group_id=php_to_django_role[php_role_id]
-            )
+            # handle duplicates in user/group association creation
+            # shouldn't happen but not impossible
+            try:
+                with transaction.atomic():
+                    UserGroups.objects.create(
+                        user_id=user_id, group_id=php_to_django_role[php_role_id]
+                    )
+            except IntegrityError:
+                print(
+                    f"Integrity error: user {user_id}, group {php_to_django_role[php_role_id]}"
+                )
 
 
 class Migration(migrations.Migration):


### PR DESCRIPTION
Adding error handling for duplicates in user/group membership conversion step of migration 20, adjusting fake_current_db to set lti.id to an unsigned bigint field.