### PR TITLE
Changes 'Compare with Class' behavior.

### DIFF
--- a/src/components/score-overview.jsx
+++ b/src/components/score-overview.jsx
@@ -1,18 +1,27 @@
-import React, { useState, useEffect } from 'react'
+import React, { useState } from 'react'
 import { apiGetScoreSummary } from '../util/api'
 import { useQuery } from 'react-query'
 import BarGraph from './bar-graph'
+import LoadingIcon from './loading-icon'
 
 const ScoreOverview = ({inst_id, single_id, overview, attemptNum, isPreview, guestAccess}) => {
 
-	const [showGraph, setShowGraph] = useState(null)
+	const [showGraph, setShowGraph] = useState(false)
+	const [fetchedOverview, setFetchedOverview] = useState(false)
+
+	const fetchOrDisplayOverview = () => {
+		setShowGraph(!showGraph)
+		if ( ! fetchedOverview) {
+			setFetchedOverview(true)
+		}
+	}
 
 	// Gets score summary
-	const { data: scoreSummary } = useQuery({
+	const { data: scoreSummary, isFetching } = useQuery({
 		queryKey: ['score-summary', inst_id],
 		queryFn: () => apiGetScoreSummary(inst_id),
 		staleTime: Infinity,
-		enabled: !!inst_id && !single_id,
+		enabled: !!inst_id && !single_id && fetchedOverview,
 		retry: false
 	})
 
@@ -33,6 +42,15 @@ const ScoreOverview = ({inst_id, single_id, overview, attemptNum, isPreview, gue
 				}
 			</div>
 		)
+	} else if (isFetching) {
+		scoreGraphRender = (
+			<div className='graph loading'>
+				<LoadingIcon size="sm" position="relative"></LoadingIcon>
+				<p className="loading-text">Loading class scores ...</p>
+			</div>
+		)
+	} else {
+		<p>Error fetching score comparison.</p>
 	}
 
 	let overviewTable = []
@@ -48,9 +66,9 @@ const ScoreOverview = ({inst_id, single_id, overview, attemptNum, isPreview, gue
 	})
 
 	let classRankBtn = null
-	if (!isPreview && scoreSummary) {
+	if ( ! isPreview ) {
 		classRankBtn = (
-			<div id="class-rank-button" className="action_button" onClick={() => setShowGraph(!showGraph)}>
+			<div id="class-rank-button" className="action_button" onClick={fetchOrDisplayOverview}>
 				{`${showGraph ? 'Close' : 'Compare With Class'}`}
 			</div>
 		)

--- a/src/components/scores.scss
+++ b/src/components/scores.scss
@@ -753,17 +753,30 @@ article {
 section.score-graph {
 	max-height: 0;
 	overflow: hidden;
-	transition: max-height 0.5s linear;
+	transition: max-height 0.15s ease-in-out;
 
 	.graph {
-		width: 746px;
-		height: 320px;
+		&:not(.loading) {
+			max-height: 320px;
+		}
 
-		margin: 15px auto 0 auto;
+		&.loading {
+			max-height: 80px;
+
+			.loading-text {
+				margin: 15px auto 0;
+			}
+		}
+
+		margin: 15px auto 0;
 		padding: 20px 16px 0 16px;
+
+		width: 746px;
 
 		background: #fff;
 		box-shadow: inset 0px 1px 2px #333;
+
+		transition: max-height 0.15s ease-in-out;
 
 		.jqplot-yaxis-label {
 			padding-left: 5px;
@@ -771,7 +784,7 @@ section.score-graph {
 	}
 
 	&.open {
-		max-height: 600px;
+		max-height: 320px;
 	}
 }
 


### PR DESCRIPTION
Closes #312.

Changes the behavior of the score screen from immediately making a call to `api/instances/instid/performance/` on page load to waiting until the 'Compare with Class' button is clicked.

Adjusts the `ScoreOverview` component's contents and styles to account for the new 'loading' state.