### PR TITLE
Fixes media importer sort

### DIFF
--- a/src/components/media-importer.jsx
+++ b/src/components/media-importer.jsx
@@ -76,7 +76,7 @@ const MediaImporter = () => {
 						id: asset.id,
 						type: asset.file_type,
 						name: asset.title.split('.').shift(),
-						timestamp: asset.created_at,
+						timestamp: creationDate,
 						thumb: _thumbnailUrl(asset.id, asset.file_type),
 						created: [creationDate.getMonth(), creationDate.getDate(), creationDate.getFullYear()].join('/'),
 						is_deleted: parseInt(asset.is_deleted) || asset.is_deleted === true


### PR DESCRIPTION
## Problem
The `sortNumber` comparator uses subtraction (`a - b`), which returns `NaN` for ISO formatted strings

## Solution
Updated timestamps to Date objects which does return a valid time difference upon subtraction

## Testing
Added my own media and ensured date sorting works for oldest to newest and newest to oldest