### PR TITLE
Asset driver improvements

### DIFF
--- a/app/materia/settings/storage.py
+++ b/app/materia/settings/storage.py
@@ -38,7 +38,6 @@ DRIVER_SETTINGS = {
             "AWS_SECRET_ACCESS_KEY",
             os.environ.get("ASSET_STORAGE_S3_SECRET", "SECRET"),
         ),
-        "token": os.environ.get("AWS_SESSION_TOKEN", "TOKEN"),  # aws session token
         # use fakes3 unless explicitly disabled: this value is always false for prod
         "fakes3_enabled": ValidatorUtil.validate_bool(
             os.environ.get("DEV_ONLY_USE_FAKES3", True),

--- a/app/storage/db.py
+++ b/app/storage/db.py
@@ -10,6 +10,8 @@ logger = logging.getLogger(__name__)
 
 
 class DBAssetStorageDriver:
+
+    @staticmethod
     def exists(asset_id, size):
         from core.models import AssetData
 
@@ -18,6 +20,7 @@ class DBAssetStorageDriver:
         except AssetData.DoesNotExist:
             return False
 
+    @staticmethod
     def store(asset, asset_path, size):
         from core.models import AssetData
 
@@ -46,6 +49,7 @@ class DBAssetStorageDriver:
                 exc_info=True,
             )
 
+    @staticmethod
     def render(asset, size):
         from core.models import AssetData
         from django.http import HttpResponse, HttpResponseNotFound
@@ -78,6 +82,7 @@ class DBAssetStorageDriver:
 
         return asset_response
 
+    @staticmethod
     def handle_uploaded_file(asset, uploaded_file):
         from core.models import AssetData
 
@@ -99,6 +104,7 @@ class DBAssetStorageDriver:
             logger.error("DB driver file upload error", exc_info=True)
 
     # Build a specified size of an asset; either 'original', 'large', or 'thumbnail'
+    @staticmethod
     def build_size(asset, size):
         from core.models import AssetData
         from PIL import Image
@@ -156,6 +162,7 @@ class DBAssetStorageDriver:
 
         return resized_bytes.getvalue()
 
+    @staticmethod
     def migrate_to(driver, cleanup_delete=False):
         from core.models import Asset, AssetData
 

--- a/app/storage/file.py
+++ b/app/storage/file.py
@@ -8,20 +8,25 @@ logger = logging.getLogger(__name__)
 
 
 class FileAssetStorageDriver:
+
+    @staticmethod
     def get_local_file_path(id, size):
         return os.path.realpath(os.path.join(settings.DIRS["media"], f"{id}_{size}"))
 
+    @staticmethod
     def exists(asset_id, size):
         return os.path.isfile(
             FileAssetStorageDriver.get_local_file_path(asset_id, size)
         )
 
+    @staticmethod
     def store(asset, image_path, size):
         if not asset.is_valid():
             raise Exception("Invalid asset for storing")
         file = FileAssetStorageDriver.get_local_file_path(asset.id, size)
         shutil.copyfile(image_path, file)
 
+    @staticmethod
     def render(asset, size):
         from django.http import HttpResponse, HttpResponseNotFound
 
@@ -57,6 +62,7 @@ class FileAssetStorageDriver:
 
             return asset_response
 
+    @staticmethod
     def handle_uploaded_file(asset, uploaded_file):
         write_path = FileAssetStorageDriver.get_local_file_path(asset.id, "original")
 
@@ -65,6 +71,7 @@ class FileAssetStorageDriver:
                 file_out.write(chunk)
 
     # Build a specified size of an asset; either 'original', 'large', or 'thumbnail'
+    @staticmethod
     def build_size(asset, size):
         from PIL import Image
 
@@ -123,6 +130,7 @@ class FileAssetStorageDriver:
 
         return resized_asset_path
 
+    @staticmethod
     def migrate_to(driver, cleanup_delete=False):
         from core.models import Asset
 

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -12,17 +12,6 @@ from django.http import HttpResponseNotFound, HttpResponseRedirect
 logger = logging.getLogger(__name__)
 
 # Thread-safe cache for S3 clients and resources
-#
-# IMPORTANT: boto3 Session objects are NOT thread-safe and must not be shared.
-# However, Client and Resource objects created from a session ARE thread-safe
-# and can be safely shared across threads.
-#
-# This cache stores only the Client and Resource objects (which are thread-safe),
-# not the Session objects. Sessions are created temporarily and discarded after
-# creating the client/resource.
-#
-# Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/session.html
-# "Resource and client objects are thread safe."
 _s3_cache_lock = threading.Lock()
 _s3_client_cache = None
 _s3_resource_cache = None

--- a/app/storage/s3.py
+++ b/app/storage/s3.py
@@ -2,6 +2,7 @@ import io
 import logging
 import os
 import tempfile
+import threading
 
 import boto3
 import botocore
@@ -10,13 +11,32 @@ from django.http import HttpResponseNotFound, HttpResponseRedirect
 
 logger = logging.getLogger(__name__)
 
+# Thread-safe cache for S3 clients and resources
+#
+# IMPORTANT: boto3 Session objects are NOT thread-safe and must not be shared.
+# However, Client and Resource objects created from a session ARE thread-safe
+# and can be safely shared across threads.
+#
+# This cache stores only the Client and Resource objects (which are thread-safe),
+# not the Session objects. Sessions are created temporarily and discarded after
+# creating the client/resource.
+#
+# Reference: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/session.html
+# "Resource and client objects are thread safe."
+_s3_cache_lock = threading.Lock()
+_s3_client_cache = None
+_s3_resource_cache = None
+_s3_cache_config = None
+
 
 class S3AssetStorageDriver:
 
+    @staticmethod
     def get_key_name(id, size):
         subdir = settings.DRIVER_SETTINGS["s3"]["subdir"]
         return os.path.join(subdir or "", f"{id}_{size}")
 
+    @staticmethod
     def get_view_url(id, size):
 
         # presigned urls work, but for fakes3 let's just return an unsigned path
@@ -45,54 +65,87 @@ class S3AssetStorageDriver:
         except Exception:
             return HttpResponseNotFound()
 
+    @staticmethod
     def get_s3(get_client=False):
+        """
+        Get a cached S3 client or resource, or create them if not available in cache
+        """
+        global _s3_client_cache, _s3_resource_cache, _s3_cache_config, _s3_cache_lock
+
         s = settings.DRIVER_SETTINGS["s3"]
 
-        try:
-            # Configure credentials depending on whether we're providing them from env or Amazon's IMDSv2 service
-            # IMDS is HIGHLY recommended for prod usage on AWS
-            session = None
-            if s["credential_provider"] == "imds":
-                # Credentials are sourced from the EC2 instance's IAM role
-                session = boto3.Session()
-            elif s["credential_provider"] == "env":
-                session_config = {
-                    "region_name": s["region"],
-                    "aws_access_key_id": s["key"],
-                    "aws_secret_access_key": s["secret_key"],
-                    "aws_session_token": s["token"] or None,
-                }
-                session = boto3.Session(**session_config)
+        # Create a hashable config tuple to detect if settings have changed
+        current_config = (
+            s.get("credential_provider"),
+            s.get("region"),
+            s.get("endpoint"),
+            s.get("bucket"),
+            s.get("fakes3_enabled", False),
+            s.get("force_path_style", False),
+            s.get("key"),
+            s.get("secret_key"),
+        )
+
+        # Thread-safe cache check and initialization
+        with _s3_cache_lock:
+            # If config changed, invalidate cache
+            if _s3_cache_config != current_config:
+                _s3_client_cache = None
+                _s3_resource_cache = None
+                _s3_cache_config = current_config
+
+            # Return cached client/resource if available
+            if get_client and _s3_client_cache is not None:
+                return _s3_client_cache
+            elif not get_client and _s3_resource_cache is not None:
+                return _s3_resource_cache
+
+            # Create new session and client/resource
+            # We only cache the client/resource objects created from it
+            try:
+                # Configure credentials depending on whether we're providing them from env or Amazon's IMDSv2 service
+                # IMDS is HIGHLY recommended for prod usage on AWS
+                session = None
+                if s["credential_provider"] == "imds":
+                    # Credentials are sourced from the EC2 instance's IAM role
+                    session = boto3.Session()
+                elif s["credential_provider"] == "env":
+                    session_config = {
+                        "region_name": s["region"],
+                        "aws_access_key_id": s["key"],
+                        "aws_secret_access_key": s["secret_key"],
+                    }
+                    session = boto3.Session(**session_config)
+                else:
+                    raise Exception(
+                        "S3: Failed to determine credential provider. Did you set the appropriate environment variable?"
+                    )
+            except Exception:
+                logger.error("S3: Failed to create S3 session.", exc_info=True)
+                raise
+
+            s3_config = {}
+            # Endpoint config is only required for fakeS3 - the param is not required for actual S3 on AWS
+            if "fakes3_enabled" in s and s["fakes3_enabled"]:
+                s3_config["endpoint_url"] = s["endpoint"]
+
+            if "force_path_style" in s and s["force_path_style"]:
+                s3_config["s3"] = {"addressing_style": "path"}
+
+            # Cache the client or resource (thread-safe objects)
+            # The session object is discarded after this and not cached
+            if get_client:
+                _s3_client_cache = session.client("s3", **s3_config)
+                return _s3_client_cache
             else:
-                raise Exception(
-                    "S3: Failed to determine credential provider. Did you set the appropriate environment variable?"
-                )
-        except Exception:
-            logger.error("S3: Failed to create S3 session.", exc_info=True)
+                _s3_resource_cache = session.resource("s3", **s3_config)
+                return _s3_resource_cache
 
-        s3_config = {}
-        # Endpoint config is only required for fakeS3 - the param is not required for actual S3 on AWS
-        if "fakes3_enabled" in s and s["fakes3_enabled"]:
-            s3_config["endpoint_url"] = s["endpoint"]
-
-        if "force_path_style" in s and s["force_path_style"]:
-            s3_config["s3"] = {"addressing_style": "path"}
-
-        if get_client:
-            return session.client("s3", **s3_config)
-        else:
-            return session.resource("s3", **s3_config)
-
+    @staticmethod
     def store(asset, image_path, size):
         if not asset.is_valid():
             raise Exception("Invalid asset for storing")
 
-        # TODO: tie these to an env variable to verbosely log S3 actions, or just toss them?
-        # logger.info(f"Storing asset data in s3: {key} ({asset.get_mime_type()})")
-        # logger.info(f"Asset data path: {image_path}")
-        # logger.info(f"Size: {size}")
-        # logger.info(f"Bucket: {bucket}")
-        # logger.info(f"Asset file_size: {asset.file_size}")
         key = S3AssetStorageDriver.get_key_name(asset.id, size)
 
         try:
@@ -106,6 +159,7 @@ class S3AssetStorageDriver:
         except Exception:
             logger.error("S3: Failed to store asset %s", key, exc_info=True)
 
+    @staticmethod
     def exists(id, size):
         s3_resource = S3AssetStorageDriver.get_s3()
         try:
@@ -119,11 +173,12 @@ class S3AssetStorageDriver:
             else:
                 logger.error("S3 exists check error", exc_info=True)
 
+    @staticmethod
     def handle_uploaded_file(asset, uploaded_file):
         s3_client = S3AssetStorageDriver.get_s3(True)
         uploaded_file.seek(0)
 
-        # Need to use a file buffer in order to access the original file again after uploading to S3 
+        # Need to use a file buffer in order to access the original file again after uploading to S3
         file_bytes = uploaded_file.read()
         file_buffer = io.BytesIO(file_bytes)
 
@@ -138,6 +193,7 @@ class S3AssetStorageDriver:
         thumbnail_buffer = io.BytesIO(file_bytes)
         S3AssetStorageDriver.build_size(asset, "thumbnail", s3_client, thumbnail_buffer)
 
+    @staticmethod
     def render(asset, size):
         from django.http import HttpResponseNotFound
 
@@ -159,11 +215,12 @@ class S3AssetStorageDriver:
             return HttpResponseNotFound()
 
         return HttpResponseRedirect(asset_url)
-    
-    def build_size(asset, size, client, uploaded_file = None):
+
+    @staticmethod
+    def build_size(asset, size, client, uploaded_file=None):
         from PIL import Image
 
-        # Get the correct file size 
+        # Get the correct file size
         crop = size == "thumbnail"
         target_size = None
         if size == "thumbnail":
@@ -173,10 +230,10 @@ class S3AssetStorageDriver:
         else:
             raise Exception(f"Asset size not supported: '{size}'")
 
-        # Get image from the uploaded file or get the the file from the asset id 
+        # Get image from the uploaded file or get the the file from the asset id
         img = None
         temporary_file = None
-        if(uploaded_file):
+        if uploaded_file:
             uploaded_file.seek(0)
             img = Image.open(uploaded_file)
         else:
@@ -186,10 +243,9 @@ class S3AssetStorageDriver:
             temporary_file = tempfile.NamedTemporaryFile(dir=tempfile.gettempdir())
             if os.path.isfile(temporary_file.name):
                 temporary_file.close()
-            client.Bucket(bucket).download_file(key, temporary_file.name)
+            client.download_file(bucket, key, temporary_file.name)
             img = Image.open(temporary_file.name)
-        
-        
+
         new_size = (0, 0)
         # if the image is wider than it is tall, constrain height
         original_width, original_height = img.size
@@ -218,7 +274,6 @@ class S3AssetStorageDriver:
             )
             img = img.crop(crop_dimensions)
 
-        
         new_file_format = asset.file_type.upper()
         # Pillow does not recognize 'JPG' as a valid file format
         if new_file_format == "JPG":
@@ -236,16 +291,19 @@ class S3AssetStorageDriver:
                 ExtraArgs={"ContentType": asset.get_mime_type()},
             )
 
-            if(temporary_file and not uploaded_file):
+            if temporary_file and not uploaded_file:
                 os.remove(temporary_file.name)
-                
-            return S3AssetStorageDriver.get_view_url(asset.id, size) 
-        except Exception:
-            if(temporary_file and not uploaded_file):
-                os.remove(temporary_file.name)
-            logger.error("Error saving thumbnail to S3", exc_info=True,)
-        
 
+            return S3AssetStorageDriver.get_view_url(asset.id, size)
+        except Exception:
+            if temporary_file and not uploaded_file:
+                os.remove(temporary_file.name)
+            logger.error(
+                "Error saving thumbnail to S3",
+                exc_info=True,
+            )
+
+    @staticmethod
     def migrate_to(driver, cleanup_delete=False):
         if driver == "file":
             from .file import FileAssetStorageDriver

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -46,7 +46,8 @@ REDIS_URL="redis://redis:6379/0"
 
 # Where AWS credentials will be sourced
 # ALLOWED VALUES: env | imds
-ASSET_STORAGE_S3_CREDENTIAL_PROVIDER=imds
+# env used for local development with fakes3. imds is highly recommended for production instances.
+ASSET_STORAGE_S3_CREDENTIAL_PROVIDER=env
 ASSET_STORAGE_S3_REGION="us-east-1"
 ASSET_STORAGE_S3_BUCKET=""
 
@@ -63,11 +64,8 @@ ASSET_STORAGE_S3_CDN_DOMAIN=""
 ASSET_STORAGE_S3_BASEPATH="media"
 
 # If using 'env' as credential provider, specify access key/secret here
-AWS_ACCESS_KEY_ID=""
-ASSET_STORAGE_S3_SECRET=""
-
-# Session token if you're not using imds (NOT recommended)
-AWS_SESSION_TOKEN=""
+AWS_ACCESS_KEY_ID=
+ASSET_STORAGE_S3_SECRET=
 
 # Set to false if using real S3 for local development
 # ALLOWED VALUES: true | false

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -49,7 +49,7 @@ REDIS_URL="redis://redis:6379/0"
 # env used for local development with fakes3. imds is highly recommended for production instances.
 ASSET_STORAGE_S3_CREDENTIAL_PROVIDER=env
 ASSET_STORAGE_S3_REGION="us-east-1"
-ASSET_STORAGE_S3_BUCKET=""
+ASSET_STORAGE_S3_BUCKET=
 
 # the most effective way to serve s3 assets is through a cloudfront distribution
 # if enabled, the s3 driver will attempt to serve them from the domain provided
@@ -57,7 +57,7 @@ ASSET_STORAGE_S3_BUCKET=""
 # ALLOWED VALUES: true | false
 ASSET_STORAGE_S3_USE_CDN=false
 # CDN domain that asset paths are appended to. Must include protocol (https://)
-ASSET_STORAGE_S3_CDN_DOMAIN=""
+ASSET_STORAGE_S3_CDN_DOMAIN=
 
 # directory on disk to store original and resized assets
 # this is effectively the subdir of the bucket where assets are hosted

--- a/docker/.env_template
+++ b/docker/.env_template
@@ -45,8 +45,8 @@ REDIS_URL="redis://redis:6379/0"
 # REQUIRED if ASSET_STORAGE_DRIVER=s3
 
 # Where AWS credentials will be sourced
-# ALLOWED VALUES: env | imds
 # env used for local development with fakes3. imds is highly recommended for production instances.
+# ALLOWED VALUES: env | imds
 ASSET_STORAGE_S3_CREDENTIAL_PROVIDER=env
 ASSET_STORAGE_S3_REGION="us-east-1"
 ASSET_STORAGE_S3_BUCKET=


### PR DESCRIPTION
- Adds `@staticmethod` decorators to all 3 storage driver class methods.
- Updated S3 storage driver to cache boto3 client and resource to improve performance. Notably, the boto3 `Session` object is instantiated only to create the associated `client` and `resource`, after which they are cached and the `Session` object is discarded.
- Removes AWS session key from S3 config, since this is meant to be a temporary value provisioned through AWS STS. It's not meant to be hard-coded in env. The AWS key and secret are used to configure the `Session` object as they were before.
- Cleaned up the `.env.template` to replace empty strings that would prevent default values from being assigned.
- `s3.py` linting