### PR TITLE
Passes LTI launch data through URL params instead of cache

### DIFF
--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -13,6 +13,7 @@ from core.services.widget_play_services import (
     WidgetPlayValidationService,
 )
 from core.utils.context_util import ContextUtil
+from core.utils.validator_util import ValidatorUtil
 from django.conf import settings
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.exceptions import BadRequest
@@ -187,8 +188,9 @@ class WidgetPlayView(
                         lti_association=lti_assoc,
                         ags_line_item=self.request.GET.get("ags_line_item", ""),
                         ags_user_id=self.request.GET.get("ags_user_id", ""),
-                        ags_scoring_enabled=self.request.GET.get("ags_scoring_enabled")
-                        == "True",
+                        ags_scoring_enabled=ValidatorUtil.validate_bool(
+                            self.request.GET.get("ags_scoring_enabled")
+                        ),
                     )
                     play_lti_state.save()
 
@@ -253,17 +255,11 @@ class WidgetPlayView(
             return lti_error_page(request, "error_lti_guest_mode")
 
         if LTILaunchService.is_initial_launch(request):
-            is_author = request.GET.get("is_author") == "True"
-            provisional = request.GET.get("provisional") == "True"
+            is_author = ValidatorUtil.validate_bool(request.GET.get("is_author"))
+            provisional = ValidatorUtil.validate_bool(request.GET.get("provisional"))
 
             if is_author:
-                if provisional:
-                    context = _create_lti_success_page(
-                        request, instance, provisional=True
-                    )
-                # current user is an author and already has access
-                else:
-                    context = _create_lti_success_page(request, instance)
+                context = _create_lti_success_page(request, instance, provisional)
 
         # edge case where the instructor refreshes the LTI preview page
         # since LTI launch data is not stored in session,

--- a/app/core/views/widget.py
+++ b/app/core/views/widget.py
@@ -16,18 +16,14 @@ from core.utils.context_util import ContextUtil
 from django.conf import settings
 from django.contrib.auth.mixins import PermissionRequiredMixin
 from django.core.exceptions import BadRequest
-from django.db.models import Q
 from django.http import Http404, HttpRequest
 from django.shortcuts import render
 from django.utils.decorators import method_decorator
 from django.views.decorators.cache import never_cache
 from django.views.generic import TemplateView
-from lti.ags.util import AGSUtil
 from lti.mixins import LtiLaunchMixin
-from lti.services.auth import LTIAuthService
 from lti.services.launch import LTILaunchService
 from lti.views.lti import error_page as lti_error_page
-from pylti1p3.exception import LtiException
 
 logger = logging.getLogger(__name__)
 
@@ -119,9 +115,7 @@ class WidgetPlayView(
         context_id = ""
 
         if LTILaunchService.is_initial_launch(request):
-            launch = LTILaunchService.get_launch_data_from_request(request)
-            if launch is not None:
-                context_id = LTILaunchService.get_context_id(launch)
+            context_id = request.GET.get("context_id", "")
 
         elif LTILaunchService.is_recovery_launch(request):
             play = LogPlay.objects.get(pk=request.GET.get("token"))
@@ -175,46 +169,30 @@ class WidgetPlayView(
 
         if not instance.guest_access:
 
-            # initial launch: launch data should be present in request object
+            # initial launch: LTI params are passed via URL query params
             if LTILaunchService.is_initial_launch(self.request):
                 try:
-                    launch_data = LTILaunchService.get_launch_data_from_request(
-                        self.request
-                    )
-
                     play.auth = "lti"
                     play.lti_token = play.id
-                    play.context_id = LTILaunchService.get_context_id(launch_data)
+                    play.context_id = self.request.GET.get("context_id", "")
 
-                    launch_resource_link = LTILaunchService.get_resource_link(
-                        launch_data
-                    )
-
+                    resource_link = self.request.GET.get("resource_link", "")
                     lti_assoc = Lti.objects.filter(
                         widget_instance_id=instance.id,
-                        resource_link=launch_resource_link,
+                        resource_link=resource_link,
                     ).first()
 
                     play_lti_state = LtiPlayState(
                         play=play,
                         lti_association=lti_assoc,
-                        ags_line_item=AGSUtil.get_line_item_from_launch(launch_data)
-                        or "",
-                        ags_user_id=AGSUtil.get_ags_user_id(launch_data) or "",
-                        ags_scoring_enabled=AGSUtil.is_ags_scoring_available(
-                            launch_data
-                        ),
+                        ags_line_item=self.request.GET.get("ags_line_item", ""),
+                        ags_user_id=self.request.GET.get("ags_user_id", ""),
+                        ags_scoring_enabled=self.request.GET.get("ags_scoring_enabled")
+                        == "True",
                     )
                     play_lti_state.save()
 
                     lti_token = play.id
-
-                except LtiException:
-                    logger.error(
-                        "LTI: Error: initial launch attempted for play %s, but launch data could not be recovered",
-                        play.id,
-                        exc_info=True,
-                    )
 
                 except Exception:
                     logger.error(
@@ -275,41 +253,17 @@ class WidgetPlayView(
             return lti_error_page(request, "error_lti_guest_mode")
 
         if LTILaunchService.is_initial_launch(request):
-            launch = LTILaunchService.get_launch_data_from_request(request)
+            is_author = request.GET.get("is_author") == "True"
+            provisional = request.GET.get("provisional") == "True"
 
-            if not launch:
-                return lti_error_page(request, "error_launch_recovery")
-
-            if LTIAuthService.is_user_course_author(launch):
-                # check to see if the current user has either:
-                # a. unrestricted permissions to the instance (context_id == None) OR
-                # b. restricted permission to the instance for the current context ID
-                context_id = LTILaunchService.get_context_id(launch)
-                has_visibility = (
-                    instance.permissions.filter(user=request.user)
-                    .filter(Q(context_id__isnull=True) | Q(context_id=context_id))
-                    .exists()
-                )
-
-                # current user IS an author in the course but does NOT have access
-                # grant them implicit access and provide the provisional flag to the frontend
-                if not has_visibility:
-                    instance.permissions.create(
-                        user=request.user,
-                        permission="visible",
-                        context_id=context_id,
-                    )
+            if is_author:
+                if provisional:
                     context = _create_lti_success_page(
                         request, instance, provisional=True
                     )
-
                 # current user is an author and already has access
                 else:
                     context = _create_lti_success_page(request, instance)
-
-            # LTI associations are registered during play view init, instead of deep linking
-            # This behavior is carried over from PHP Materia
-            LTILaunchService.register_association(launch, request.user, instance)
 
         # edge case where the instructor refreshes the LTI preview page
         # since LTI launch data is not stored in session,

--- a/app/lti/services/launch.py
+++ b/app/lti/services/launch.py
@@ -1,11 +1,11 @@
 import logging
 import re
 import time
+from urllib.parse import urlencode
 
 from core.message_exception import MsgNotFound
 from core.models import LogPlay, Lti, LtiPlayState, WidgetInstance
-from lti_tool.models import LtiDeployment, LtiLaunch, LtiRegistration
-from lti_tool.utils import get_launch_from_request
+from lti_tool.models import LtiDeployment, LtiRegistration
 
 # from pprint import pformat
 
@@ -113,12 +113,12 @@ class LTILaunchService:
         return deployment.registration if deployment is not None else None
 
     @staticmethod
-    def get_launch_redirect(lti_launch: LtiLaunch) -> str:
+    def get_launch_redirect(launch_data: dict, lti_params: dict = None) -> str:
         """
         Gets the appropriate redirect URI for resource link launches.
-        Should be one of three destinations: post login, widget player, or score screen
+        Should be one of three destinations: post login, widget player, or score screen.
+        For widget launches, LTI params are appended as query params.
         """
-        launch_data = lti_launch.get_launch_data()
         uri_claim = launch_data.get(
             "https://purl.imsglobal.org/spec/lti/claim/target_link_uri"
         )
@@ -127,9 +127,7 @@ class LTILaunchService:
         if not uri_claim or re.search("/ltilaunch/", uri_claim):
             return "/lti/post_login/"
 
-        # widget launches require special processing
-        # we provide the launch ID as a query param so we can distinguish LTI plays from non-LTI
-        # referencing request.lti_launch is NOT enough because one may be cached in session
+        # widget launches: append LTI params as query params
         elif LTILaunchService.is_widget_launch(
             launch_data
         ) or LTILaunchService.is_legacy_widget_launch_url(uri_claim):
@@ -137,8 +135,8 @@ class LTILaunchService:
             if LTILaunchService.is_legacy_widget_launch_url(uri_claim):
                 uri_claim = LTILaunchService.upgrade_widget_launch_url(uri_claim)
 
-            lid = lti_launch.get_launch_id()
-            uri_claim = f"{uri_claim}?lid={lid}"
+            if lti_params:
+                uri_claim = f"{uri_claim}?{urlencode(lti_params)}"
             return uri_claim
 
         # expected to be a score screen at this point
@@ -246,10 +244,10 @@ class LTILaunchService:
     def is_initial_launch(request) -> bool:
         """
         Helper method to determine if the request is an initial widget launch
-        based on the presence of the ?lid GET parameter.
+        based on the presence of the ?context_id GET parameter.
         """
-        launch_id = request.GET.get("lid", None)
-        return launch_id is not None
+        context_id = request.GET.get("context_id", None)
+        return context_id is not None
 
     @staticmethod
     def is_recovery_launch(request) -> bool:
@@ -261,17 +259,6 @@ class LTILaunchService:
         """
         token_param = request.GET.get("token")
         return token_param is not None
-
-    @staticmethod
-    def get_launch_data_from_request(request):
-        """
-        Retrieves launch data from the request using the ?lid GET parameter as a key
-        """
-        launch_id = request.GET.get("lid", None)
-        if launch_id is not None:
-            launch = get_launch_from_request(request, launch_id)
-            launch_data = None if launch is None else launch.get_launch_data()
-            return launch_data
 
     @staticmethod
     def get_launch_from_play(play_id: str) -> LtiPlayState:

--- a/app/lti/services/launch.py
+++ b/app/lti/services/launch.py
@@ -244,10 +244,9 @@ class LTILaunchService:
     def is_initial_launch(request) -> bool:
         """
         Helper method to determine if the request is an initial widget launch
-        based on the presence of the ?context_id GET parameter.
+        based on the presence of the ?launch_status=initial GET parameter.
         """
-        context_id = request.GET.get("context_id", None)
-        return context_id is not None
+        return request.GET.get("launch_status") == "initial"
 
     @staticmethod
     def is_recovery_launch(request) -> bool:

--- a/app/lti/views/launch.py
+++ b/app/lti/views/launch.py
@@ -1,6 +1,9 @@
 import logging
 
+from core.models import WidgetInstance
+from django.db.models import Q
 from django.shortcuts import redirect
+from lti.ags.util import AGSUtil
 from lti.exceptions import LTIAuthException
 from lti.services.auth import LTIAuthService
 from lti.services.launch import LTILaunchService
@@ -38,9 +41,69 @@ class ApplicationLaunchView(LtiLaunchBaseView):
             # LTI auth exception is raised when critical auth data is missing
             return error_page(request, "error_unknown_user")
 
+        # Build LTI params to pass via URL for widget launches
+        lti_params = {}
+        if LTILaunchService.is_widget_launch(
+            launch_data
+        ) or LTILaunchService.is_legacy_widget_launch_url(
+            launch_data.get(
+                "https://purl.imsglobal.org/spec/lti/claim/target_link_uri", ""
+            )
+        ):
+            context_id = LTILaunchService.get_context_id(launch_data)
+            lti_params = {
+                "context_id": context_id,
+                "resource_link": LTILaunchService.get_resource_link(launch_data) or "",
+                "ags_line_item": AGSUtil.get_line_item_from_launch(launch_data) or "",
+                "ags_user_id": AGSUtil.get_ags_user_id(launch_data) or "",
+                "ags_scoring_enabled": str(
+                    AGSUtil.is_ags_scoring_available(launch_data)
+                ),
+            }
+
+            # Perform author check and association registration here
+            # so downstream views don't need the full launch data
+            uri_claim = launch_data.get(
+                "https://purl.imsglobal.org/spec/lti/claim/target_link_uri", ""
+            )
+            inst_id = LTILaunchService.get_inst_id_from_uri(uri_claim)
+            if inst_id:
+                instance = WidgetInstance.objects.filter(pk=inst_id).first()
+                if instance:
+                    is_author = LTIAuthService.is_user_course_author(launch_data)
+                    lti_params["is_author"] = str(is_author)
+
+                    # check to see if the current user has either:
+                    # a. unrestricted permissions to the instance (context_id == None) OR
+                    # b. restricted permission to the instance for the current context ID
+                    if is_author:
+                        has_visibility = (
+                            instance.permissions.filter(user=request.user)
+                            .filter(
+                                Q(context_id__isnull=True) | Q(context_id=context_id)
+                            )
+                            .exists()
+                        )
+
+                        # current user IS an author in the course but does NOT have access
+                        # grant them implicit access and provide the provisional flag to the frontend
+                        if not has_visibility:
+                            instance.permissions.create(
+                                user=request.user,
+                                permission="visible",
+                                context_id=context_id,
+                            )
+                            lti_params["provisional"] = "True"
+
+                    # LTI associations are registered during play view init, instead of deep linking
+                    # This behavior is carried over from PHP Materia
+                    LTILaunchService.register_association(
+                        launch_data, request.user, instance
+                    )
+
         # Redirect handling
         try:
-            destination = LTILaunchService.get_launch_redirect(lti_launch)
+            destination = LTILaunchService.get_launch_redirect(launch_data, lti_params)
             return redirect(destination)
         except Exception:
             return error_page(request, "error_unknown_assignment")

--- a/app/lti/views/launch.py
+++ b/app/lti/views/launch.py
@@ -52,6 +52,7 @@ class ApplicationLaunchView(LtiLaunchBaseView):
         ):
             context_id = LTILaunchService.get_context_id(launch_data)
             lti_params = {
+                "launch_status": "initial",
                 "context_id": context_id,
                 "resource_link": LTILaunchService.get_resource_link(launch_data) or "",
                 "ags_line_item": AGSUtil.get_line_item_from_launch(launch_data) or "",
@@ -100,6 +101,8 @@ class ApplicationLaunchView(LtiLaunchBaseView):
                     LTILaunchService.register_association(
                         launch_data, request.user, instance
                     )
+            else:
+                return error_page(request, "error_unknown_assignment")
 
         # Redirect handling
         try:


### PR DESCRIPTION
Resolves #319 

## Summary                                                                                                                                                                                          
  - Extracts LTI values from the validated JWT in `handle_resource_launch()` and appends them as URL query params on the redirect                                                                     
  - Simplifies `WidgetPlayView` by reading from query params instead of looking up cached launch data through `get_launch_data_from_request()`