### PR TITLE
Adds content hash cache busting for frontend assets

### DIFF
--- a/app/core/utils/asset_manifest.py
+++ b/app/core/utils/asset_manifest.py
@@ -1,0 +1,23 @@
+import json
+import os
+
+from django.conf import settings
+
+
+class AssetManifest:
+    _manifest = None
+
+    @classmethod
+    def _load_manifest(cls):
+        manifest_path = os.path.join(str(settings.APP_PATH), "public", "manifest.json")
+        try:
+            with open(manifest_path) as f:
+                cls._manifest = json.load(f)
+        except (FileNotFoundError, json.JSONDecodeError):
+            cls._manifest = {}
+
+    @classmethod
+    def resolve(cls, path):
+        if cls._manifest is None:
+            cls._load_manifest()
+        return cls._manifest.get(path, path)

--- a/app/core/utils/context_util.py
+++ b/app/core/utils/context_util.py
@@ -1,3 +1,4 @@
+from core.utils.asset_manifest import AssetManifest
 from django.conf import settings
 from django.http import HttpRequest
 
@@ -31,6 +32,13 @@ class ContextUtil:
         processed_js_resources.insert(0, settings.JS_BASEURL + "commons.js")
         processed_css_resources.insert(0, settings.CSS_BASEURL + "fonts.css")
         processed_css_resources.insert(1, settings.CSS_BASEURL + "commons.css")
+
+        processed_js_resources = [
+            AssetManifest.resolve(r) for r in processed_js_resources
+        ]
+        processed_css_resources = [
+            AssetManifest.resolve(r) for r in processed_css_resources
+        ]
 
         # Create and return context
         return {

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -4,6 +4,9 @@ const path = require('path')
 const MiniCssExtractPlugin = require('mini-css-extract-plugin')
 const WebpackRemoveEmptyScriptsPlugin = require('webpack-remove-empty-scripts')
 const BundleTracker = require('webpack-bundle-tracker')
+const { WebpackManifestPlugin } = require('webpack-manifest-plugin')
+
+const WIDGET_CORE_BUNDLES = ['materia.enginecore', 'materia.creatorcore', 'materia.scorecore']
 
 const jsPath = path.join(__dirname, 'src')
 const packageJsPath = path.join(__dirname, 'fuel', 'packages')
@@ -45,7 +48,12 @@ module.exports = {
 	entry,
 	output: {
 		path: path.join(__dirname, 'public/'),
-		filename: 'js/[name].js',
+		filename: (pathData) => {
+			if (WIDGET_CORE_BUNDLES.includes(pathData.chunk.name)) {
+				return 'js/[name].js'
+			}
+			return 'js/[name].[contenthash:8].js'
+		},
 		publicPath: '/static/',
 	},
 	module: {
@@ -93,7 +101,19 @@ module.exports = {
 		new BundleTracker({ filename: './webpack-stats.json' }),
 		new WebpackRemoveEmptyScriptsPlugin(),
 		new MiniCssExtractPlugin({
-			filename: 'css/[name].css',
+			filename: 'css/[name].[contenthash:8].css',
+		}),
+		new WebpackManifestPlugin({
+			fileName: 'manifest.json',
+			publicPath: '',
+			generate: (seed, files, entries) => {
+				const manifest = {}
+				files.forEach(file => {
+					const dir = file.path.substring(0, file.path.lastIndexOf('/') + 1)
+					manifest[dir + file.name] = file.path
+				})
+				return manifest
+			}
 		}),
 	],
 	resolve: {


### PR DESCRIPTION
## Problem
Frontend assets (JS/CSS) are served by nginx with long-lived cache headers (7 days). When the backend is updated to a new version, browsers continue serving stale JS files from cache. These stale files may reference outdated API endpoints, breaking the application for users until the cache expires.

## Solution
Webpack production builds now include content hashes in output filenames. When file content changes, the filename changes, forcing browsers to fetch the new version. A manifest.json generated at build time maps original names to hashed names, which Django reads to resolve the correct asset URLs at runtime.

## Testing
Ran `npm run build-for-image` and verified `public/manifest.json` has correct mappings