### PR TITLE
Playdata exports respect provisional access

### DIFF
--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -10,7 +10,7 @@ from core.models import (
 )
 from core.services.perm_service import PermService
 from core.services.semester_service import SemesterService
-from django.db.models import OuterRef, Q, Subquery
+from django.db.models import OuterRef, Q, Subquery, Value
 from django_filters import rest_framework
 from rest_framework import filters
 
@@ -78,25 +78,31 @@ class LogPlayFilterBackend(filters.BaseFilterBackend):
             return queryset.filter(user=user).order_by("-created_at")
         # user is requesting an arbitrary user's logs: requires elevated perms or self
         elif user_query is not None:
-            if (
-                user.is_superuser
-                or user.groups.filter(name="support_user").exists()
-                or str(user.id) == user_query
-            ):
+            if PermService.is_superuser_or_elevated(user) or str(user.id) == user_query:
                 return queryset.filter(user=user_query).order_by("-created_at")
             else:
                 return queryset.none()
 
         elif inst_id is not None:
-            semester = request.query_params.get("semester", None)
-            year = request.query_params.get("year", None)
-            context_ids = request.query_params.get("context_ids", None)
 
             instance = WidgetInstance.objects.filter(id=inst_id).first()
-            if instance is not None:
-                return instance.get_play_logs(
-                    semester=semester, year=year, context_ids=context_ids
+            if instance is None:
+                return queryset.none()
+
+            semester = request.query_params.get("semester", None)
+            year = request.query_params.get("year", None)
+
+            qs = instance.get_play_logs_for_user(
+                user=user, semester=semester, year=year
+            )
+
+            if PermService.user_is_student(user):
+                qs = qs.annotate(
+                    user=Value(None),
+                    user_id=Value(None),
                 )
+
+            return qs
 
             # user wants ALL the logs
         elif pk is None and user_query is None:

--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -10,7 +10,7 @@ from core.models import (
 )
 from core.services.perm_service import PermService
 from core.services.semester_service import SemesterService
-from django.db.models import OuterRef, Q, Subquery, Value
+from django.db.models import OuterRef, Q, Subquery
 from django_filters import rest_framework
 from rest_framework import filters
 
@@ -95,12 +95,6 @@ class LogPlayFilterBackend(filters.BaseFilterBackend):
             qs = instance.get_play_logs_for_user(
                 user=user, semester=semester, year=year
             )
-
-            if PermService.user_is_student(user):
-                qs = qs.annotate(
-                    user=Value(None),
-                    user_id=Value(None),
-                )
 
             return qs
 

--- a/app/api/tests/base.py
+++ b/app/api/tests/base.py
@@ -1,0 +1,54 @@
+"""Base test case with common setup for all tests."""
+
+from core.models import DateRange
+from dateutil import parser, tz
+from django.conf import settings
+from django.contrib.auth.models import Group
+from django.test import TestCase
+
+
+class MateriaTestCase(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+
+        # database provisioning with default values
+        cls._populate_dateranges()
+        cls.author_group, _ = Group.objects.get_or_create(name="basic_author")
+        cls.support_group, _ = Group.objects.get_or_create(name="support_user")
+        cls.no_author_group, _ = Group.objects.get_or_create(name="no_author")
+
+    @classmethod
+    def _populate_dateranges(cls, start_year=2020, end_year=2032):
+        semesters = settings.SEMESTERS[0]
+        year_counter = start_year
+
+        while end_year >= year_counter:
+            seasons = list(semesters.keys())
+            for i, season in enumerate(seasons):
+                semester = semesters[season]
+
+                if i + 1 < len(seasons):
+                    next_season = seasons[i + 1]
+                    next_semester = semesters[next_season]
+
+                    start_str = f"{semester['month']}/{semester['day']}/{year_counter} at 00:00:01"
+                    end_str = f"{next_semester['month']}/{next_semester['day']}/{year_counter} at 00:00:00"
+                else:
+                    start_str = f"{semester['month']}/{semester['day']}/{year_counter} at 00:00:01"
+                    end_str = f"01/01/{year_counter + 1} at 00:00:00"
+
+                start_at = parser.parse(start_str).replace(tzinfo=tz.UTC)
+                end_at = parser.parse(end_str).replace(tzinfo=tz.UTC)
+
+                DateRange.objects.get_or_create(
+                    semester=season,
+                    year=year_counter,
+                    defaults={
+                        "start_at": start_at,
+                        "end_at": end_at,
+                    },
+                )
+
+            year_counter += 1

--- a/app/api/tests/test_playsession_views.py
+++ b/app/api/tests/test_playsession_views.py
@@ -1,10 +1,9 @@
+from core.models import DateRange, LogPlay, Widget, WidgetInstance, WidgetQset
 from django.contrib.auth.models import Group, User
 from django.test import TestCase
 from django.utils import timezone
 from rest_framework import status
 from rest_framework.test import APIClient
-
-from core.models import DateRange, LogPlay, Widget, WidgetInstance, WidgetQset
 
 
 class PlaySessionViewSetTestCase(TestCase):
@@ -181,15 +180,24 @@ class TestPlaySessionList(PlaySessionViewSetTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
-    def test_list_by_instance_returns_plays(self):
+    def test_authenticated_user_can_list_own_instance_plays(self):
+        self.client.force_authenticate(user=self.regular_user)
+        response = self.client.get(
+            "/api/play-sessions/", {"inst_id", self.regular_instance.id}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        play_ids = [play["id"] for play in response.data["results"]]
+        self.assertIn(self.user_play.id, play_ids)
+
+    def test_list_by_instance_other_owner_returns_no_plays(self):
         self.client.force_authenticate(user=self.author_user)
         response = self.client.get(
             "/api/play-sessions/", {"inst_id": self.regular_instance.id}
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        play_ids = [play["id"] for play in response.data["results"]]
-        self.assertIn(self.user_play.id, play_ids)
+        self.assertEqual(len(response.data["results"]), 0)
 
     def test_list_without_filter_returns_empty(self):
         self.client.force_authenticate(user=self.regular_user)

--- a/app/api/tests/test_playsession_views.py
+++ b/app/api/tests/test_playsession_views.py
@@ -183,7 +183,7 @@ class TestPlaySessionList(PlaySessionViewSetTestCase):
     def test_authenticated_user_can_list_own_instance_plays(self):
         self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(
-            "/api/play-sessions/", {"inst_id", self.regular_instance.id}
+            "/api/play-sessions/", {"inst_id": self.regular_instance.id}
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/app/api/tests/test_playsession_views.py
+++ b/app/api/tests/test_playsession_views.py
@@ -1,15 +1,14 @@
+from api.tests.base import MateriaTestCase
 from core.models import DateRange, LogPlay, Widget, WidgetInstance, WidgetQset
-from django.contrib.auth.models import Group, User
-from django.test import TestCase
-from django.utils import timezone
+from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.test import APIClient
 
 
-class PlaySessionViewSetTestCase(TestCase):
+class PlaySessionViewSetTestCase(MateriaTestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.author_group, _ = Group.objects.get_or_create(name="basic_author")
+        super().setUpTestData()
 
         cls.regular_user = User.objects.create_user(
             username="regular",
@@ -30,12 +29,7 @@ class PlaySessionViewSetTestCase(TestCase):
             password="testpass123",
         )
 
-        cls.semester = DateRange.objects.create(
-            semester="Fall",
-            year=2024,
-            start_at=timezone.now(),
-            end_at=timezone.now() + timezone.timedelta(days=120),
-        )
+        cls.semester = DateRange.objects.filter(semester="fall", year=2024).first()
 
         cls.widget = Widget.objects.create(
             name="Test Widget",
@@ -60,6 +54,8 @@ class PlaySessionViewSetTestCase(TestCase):
             is_draft=False,
             guest_access=False,
         )
+
+        cls.regular_instance.permissions.create(user=cls.author_user, permission="full")
 
         cls.guest_instance = WidgetInstance.objects.create(
             id="guest123",
@@ -181,7 +177,7 @@ class TestPlaySessionList(PlaySessionViewSetTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_authenticated_user_can_list_own_instance_plays(self):
-        self.client.force_authenticate(user=self.regular_user)
+        self.client.force_authenticate(user=self.author_user)
         response = self.client.get(
             "/api/play-sessions/", {"inst_id": self.regular_instance.id}
         )
@@ -191,7 +187,7 @@ class TestPlaySessionList(PlaySessionViewSetTestCase):
         self.assertIn(self.user_play.id, play_ids)
 
     def test_list_by_instance_other_owner_returns_no_plays(self):
-        self.client.force_authenticate(user=self.author_user)
+        self.client.force_authenticate(user=self.regular_user)
         response = self.client.get(
             "/api/play-sessions/", {"inst_id": self.regular_instance.id}
         )

--- a/app/api/tests/test_user_views.py
+++ b/app/api/tests/test_user_views.py
@@ -1,16 +1,14 @@
-from django.contrib.auth.models import Group, User
-from django.test import TestCase
+from api.tests.base import MateriaTestCase
+from core.models import ObjectPermission, Widget, WidgetInstance
+from django.contrib.auth.models import User
 from rest_framework import status
 from rest_framework.test import APIClient
 
-from core.models import ObjectPermission, Widget, WidgetInstance
 
-
-class UserViewSetTestCase(TestCase):
+class UserViewSetTestCase(MateriaTestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.author_group, _ = Group.objects.get_or_create(name="basic_author")
-        cls.support_group, _ = Group.objects.get_or_create(name="support_user")
+        super().setUpTestData()
 
         cls.regular_user = User.objects.create_user(
             username="regular",
@@ -319,7 +317,7 @@ class TestRolesEndpoint(UserViewSetTestCase):
         self.assertTrue(self.john_doe.groups.filter(name="basic_author").exists())
 
 
-class TestLoginEndpoint(TestCase):
+class TestLoginEndpoint(MateriaTestCase):
     """Tests for POST /api/user/login/"""
 
     @classmethod
@@ -368,7 +366,7 @@ class TestLoginEndpoint(TestCase):
         self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
 
 
-class TestLogoutEndpoint(TestCase):
+class TestLogoutEndpoint(MateriaTestCase):
     """Tests for GET /users/logout/"""
 
     @classmethod

--- a/app/api/tests/test_widget_instance_views.py
+++ b/app/api/tests/test_widget_instance_views.py
@@ -1,14 +1,7 @@
+import uuid
 from unittest.mock import patch
 
-from django.contrib.auth.models import Group, User
-from django.core.cache import cache
-from django.test import TestCase
-from django.utils import timezone
-from rest_framework import status
-from rest_framework.test import APIClient
-
-import uuid
-
+from api.tests.base import MateriaTestCase
 from core.models import (
     DateRange,
     LogPlay,
@@ -17,14 +10,17 @@ from core.models import (
     WidgetInstance,
     WidgetQset,
 )
+from django.contrib.auth.models import User
+from django.core.cache import cache
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient
 
 
-class WidgetInstanceViewSetTestCase(TestCase):
+class WidgetInstanceViewSetTestCase(MateriaTestCase):
     @classmethod
     def setUpTestData(cls):
-        cls.author_group, _ = Group.objects.get_or_create(name="basic_author")
-        cls.support_group, _ = Group.objects.get_or_create(name="support_user")
-        cls.no_author_group, _ = Group.objects.get_or_create(name="no_author")
+        super().setUpTestData()
 
         cls.regular_user = User.objects.create_user(
             username="regular",
@@ -66,12 +62,8 @@ class WidgetInstanceViewSetTestCase(TestCase):
         )
         cls.no_author_user.groups.add(cls.no_author_group)
 
-        cls.semester = DateRange.objects.create(
-            semester="Fall",
-            year=2024,
-            start_at=timezone.now(),
-            end_at=timezone.now() + timezone.timedelta(days=120),
-        )
+        # DateRanges are now populated by MateriaTestCase
+        cls.semester = DateRange.objects.filter(semester="fall", year=2024).first()
 
         cls.widget = Widget.objects.create(
             name="Test Widget",

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -32,6 +32,7 @@ from core.models import (
 from core.services.instance_service import WidgetInstanceService
 from core.services.perm_service import PermService
 from core.services.play_data_exporter_service import PlayDataExporterService
+from django.db.models import Value
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
@@ -119,7 +120,11 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
             ]
 
         # Anyone can play a widget and get its qset
-        elif self.action == "question_set" or self.action == "question_sets" or self.action == "retrieve":
+        elif (
+            self.action == "question_set"
+            or self.action == "question_sets"
+            or self.action == "retrieve"
+        ):
             permission_classes = [AllowAny]
 
         # Catch all just to block anything else
@@ -572,8 +577,32 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
         instance = self.get_object()
         is_student = PermService.user_is_student(request.user)
 
+        queryset = LogPlay.objects.none()
+        semesters = semester_ids.split(",")
+
+        # preconstruct the queryset to pass to the export service
+        if export_type != "storage":
+            for semester in semesters:
+                [year, term] = semester.split("-")
+                semester_set = instance.get_play_logs_for_user(
+                    user=request.user, semester=term, year=year
+                )
+                queryset = queryset.union(semester_set)
+
+        # since the queryset is premade, anonymize the data in one go
+        if is_student:
+            queryset = queryset.annotate(
+                user=Value(None),
+                user_id=Value(None),
+            )
+
         result, file_ext = PlayDataExporterService.export(
-            instance, export_type, semester_ids, is_student, table, anonymous
+            instance=instance,
+            export_type=export_type,
+            semesters=semesters,
+            logs=queryset,
+            table=table,
+            anonymous=anonymous,
         )
 
         # technically supposed to use DRF's Response here, but it adds additional processing that makes switching

--- a/app/api/views/widget_instances.py
+++ b/app/api/views/widget_instances.py
@@ -32,7 +32,6 @@ from core.models import (
 from core.services.instance_service import WidgetInstanceService
 from core.services.perm_service import PermService
 from core.services.play_data_exporter_service import PlayDataExporterService
-from django.db.models import Value
 from django.http import HttpResponse
 from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import viewsets
@@ -589,12 +588,13 @@ class WidgetInstanceViewSet(viewsets.ModelViewSet):
                 )
                 queryset = queryset.union(semester_set)
 
-        # since the queryset is premade, anonymize the data in one go
         if is_student:
-            queryset = queryset.annotate(
-                user=Value(None),
-                user_id=Value(None),
-            )
+            # anonymize the data by setting user to None on each instance
+            logs = list(queryset)
+            for log in logs:
+                log.user = None
+                log.user_id = None
+            queryset = logs
 
         result, file_ext = PlayDataExporterService.export(
             instance=instance,

--- a/app/core/models.py
+++ b/app/core/models.py
@@ -26,7 +26,7 @@ from django.contrib.auth.models import AnonymousUser, User
 from django.contrib.contenttypes.fields import GenericForeignKey, GenericRelation
 from django.contrib.contenttypes.models import ContentType
 from django.db import DatabaseError, models, transaction
-from django.db.models import QuerySet
+from django.db.models import Q, QuerySet
 from django.db.models.signals import post_save
 from django.dispatch import receiver
 from django.utils import timezone
@@ -1271,7 +1271,11 @@ class WidgetInstance(models.Model):
         All filters are applied combinatorially - if multiple filters are provided,
         they will all be applied together.
         """
-        queryset = self.play_logs.all().order_by("-created_at")
+        queryset = (
+            self.play_logs.all()
+            .select_related("semester", "user")
+            .order_by("-created_at")
+        )
 
         # treat "all" as None
         semester = None if semester == "all" else semester
@@ -1279,8 +1283,7 @@ class WidgetInstance(models.Model):
 
         # Apply context_ids filter if provided
         if context_ids:
-            context_id_list = [ctx.strip() for ctx in context_ids.split(",")]
-            queryset = queryset.filter(context_id__in=context_id_list)
+            queryset = queryset.filter(context_id__in=context_ids)
 
         # Apply semester and year filters if provided
         if semester and year:
@@ -1298,6 +1301,22 @@ class WidgetInstance(models.Model):
             queryset = queryset.filter(semester__in=semesters)
 
         return queryset
+
+    def get_play_logs_for_user(self, user, semester=None, year=None):
+        perms = self.permissions.filter(
+            Q(expires_at__isnull=True) | Q(expires_at__gt=timezone.now()),
+            user=user,
+        )
+
+        if not perms.exists() and not PermService.is_superuser_or_elevated(user):
+            return LogPlay.objects.none()
+
+        contexts = [perm.context_id for perm in perms if perm.context_id is not None]
+
+        if not contexts:
+            contexts = None
+
+        return self.get_play_logs(semester=semester, year=year, context_ids=contexts)
 
     @property
     def play_url(self):

--- a/app/core/services/play_data_exporter_service.py
+++ b/app/core/services/play_data_exporter_service.py
@@ -152,7 +152,7 @@ class PlayDataExporterService:
                     "score": 0,
                     "last_name": play.user.last_name,
                     "first_name": play.user.first_name,
-                    "semester": play.semester,
+                    "semester": f"{play.semester.semester} {play.semester.year}",
                 }
 
             # Update user's highest score in results dict
@@ -186,8 +186,16 @@ class PlayDataExporterService:
             if play.user:
                 continue
 
-            # Add to data list
-            data.append([f"Guest {++count}", "", "", f"{play.percent}%", play.semester])
+            count += 1
+            data.append(
+                [
+                    f"Guest {count}",
+                    "",
+                    "",
+                    f"{play.percent}%",
+                    f"{play.semester.semester} {play.semester.year}",
+                ]
+            )
 
         # Throw 404 when there is no data found
         if len(data) == 0:
@@ -234,7 +242,7 @@ class PlayDataExporterService:
                     last,
                     first,
                     play.id,
-                    play.semester,
+                    f"{play.semester.semester} {play.semester.year}",
                     play_event.log_type,
                     play_event.item_id,
                     play_event.text,

--- a/app/core/services/play_data_exporter_service.py
+++ b/app/core/services/play_data_exporter_service.py
@@ -1,14 +1,14 @@
+import inspect
 import io
 import logging
 from types import FunctionType
 from zipfile import ZIP_DEFLATED, ZipFile
 
 from core.message_exception import MsgFailure, MsgInvalidInput, MsgNotFound
-from core.models import DateRange, LogPlay, WidgetInstance
+from core.models import LogPlay, WidgetInstance
 from core.services.log_storage_service import LogStorageService
 from core.utils.validator_util import ValidatorUtil
-from django.conf import settings
-from django.core.cache import cache
+from django.db.models import QuerySet
 
 logger = logging.getLogger(__name__)
 
@@ -18,34 +18,23 @@ class PlayDataExporterService:
     def export(
         instance: WidgetInstance,
         export_type: str,
-        semesters_string: str,
-        is_student: bool,
+        semesters: list[str],
+        logs: QuerySet[LogPlay],
         table: str | None = None,
         anonymous: bool | None = None,
     ) -> tuple[str | bytes, str]:
-        semesters = semesters_string.split(",")
 
         match export_type:
             case "High Scores":
-                return PlayDataExporterService._export_high_scores(
-                    instance, semesters, is_student
-                )
+                return PlayDataExporterService._export_high_scores(instance, logs)
             case "All Scores":
-                return PlayDataExporterService._export_all_scores(
-                    instance, semesters, is_student
-                )
+                return PlayDataExporterService._export_all_scores(instance, logs)
             case "Full Event Log":
-                return PlayDataExporterService._export_full_event_log(
-                    instance, semesters, is_student
-                )
+                return PlayDataExporterService._export_full_event_log(instance, logs)
             case "Referrer URLs":
-                return PlayDataExporterService._export_referrer_urls(
-                    instance, semesters, is_student
-                )
+                return PlayDataExporterService._export_referrer_urls(instance, logs)
             case "Questions and Answers":
-                return PlayDataExporterService._export_questions_and_answers(
-                    instance, semesters
-                )
+                return PlayDataExporterService._export_questions_and_answers(instance)
             case "storage":
                 return PlayDataExporterService._export_storage_logs(
                     instance, semesters, table, anonymous
@@ -60,9 +49,26 @@ class PlayDataExporterService:
                     exporter_method, FunctionType
                 ):
                     try:
-                        result, file_ext = exporter_method(
-                            instance, semesters, is_student
-                        )
+                        # Check the method signature to determine which version to call
+                        sig = inspect.signature(exporter_method)
+                        param_names = list(sig.parameters.keys())
+
+                        # Deprecated signature: (instance, semesters, is_student)
+                        if "is_student" in param_names or "semesters" in param_names:
+                            logger.warning(
+                                "Playdata exporter '%s' for widget %s is using "
+                                "a deprecated method signature (instance, semesters, "
+                                "is_student). Use (instance, logs) instead.",
+                                export_type,
+                                instance.widget.clean_name,
+                            )
+                            result, file_ext = exporter_method(
+                                instance, semesters, is_student=True
+                            )
+                        else:
+                            # Current signature: (instance, logs)
+                            result, file_ext = exporter_method(instance, logs)
+
                         # Verify the exporter method returned correct data
                         if not (isinstance(result, str) or isinstance(result, bytes)):
                             raise MsgFailure(
@@ -118,7 +124,8 @@ class PlayDataExporterService:
 
     @staticmethod
     def _export_high_scores(
-        instance: WidgetInstance, semesters: list[str], is_student: bool
+        instance: WidgetInstance,
+        logs: QuerySet[LogPlay],
     ) -> tuple[str, str]:
         headers = [
             "Last Name",
@@ -131,32 +138,25 @@ class PlayDataExporterService:
         ]
         results = {}
 
-        # Get all play logs for each semester requested
-        for semester in semesters:
-            [year, term] = semester.split("-")
-            logs = PlayDataExporterService.get_all_plays_for_instance(
-                instance, term, int(year), is_student
-            )
+        # Go through each play log, compare current user score and this play's score
+        for play in logs:
+            # Do not include if user is guest
+            if not play.user:
+                continue
 
-            # Go through each play log, compare current user score and this play's score
-            for play in logs:
-                # Do not include if user is guest
-                if not play.user:
-                    continue
+            user_id = play.user.id
 
-                user_id = play.user.id
+            # Add user to results if not already present
+            if user_id not in results:
+                results[user_id] = {
+                    "score": 0,
+                    "last_name": play.user.last_name,
+                    "first_name": play.user.first_name,
+                    "semester": play.semester,
+                }
 
-                # Add user to results if not already present
-                if user_id not in results:
-                    results[user_id] = {
-                        "score": 0,
-                        "last_name": play.user.last_name,
-                        "first_name": play.user.first_name,
-                        "semester": semester,
-                    }
-
-                # Update user's highest score in results dict
-                results[user_id]["score"] = max(results[user_id]["score"], play.percent)
+            # Update user's highest score in results dict
+            results[user_id]["score"] = max(results[user_id]["score"], play.percent)
 
         # Throw 404 if there are no play logs
         if len(results) == 0:
@@ -174,27 +174,20 @@ class PlayDataExporterService:
     # Exports all guest scores. For use when the instance is in guest mode
     @staticmethod
     def _export_all_scores(
-        instance: WidgetInstance, semesters: list[str], is_student: bool
+        instance: WidgetInstance, logs: QuerySet[LogPlay]
     ) -> tuple[str, str]:
         headers = ["User ID", "Last Name", "First Name", "Score", "Semester"]
         data = []
         count = 0
 
-        # For each semester, get all play logs
-        for semester in semesters:
-            [year, term] = semester.split("-")
-            logs = PlayDataExporterService.get_all_plays_for_instance(
-                instance, term, int(year), is_student
-            )
+        # For each play log, process its data and add to results
+        for play in logs:
+            # Ignore non-guest plays
+            if play.user:
+                continue
 
-            # For each play log, process its data and add to results
-            for play in logs:
-                # Ignore non-guest plays
-                if play.user:
-                    continue
-
-                # Add to data list
-                data.append([f"Guest {++count}", "", "", f"{play.percent}%", semester])
+            # Add to data list
+            data.append([f"Guest {++count}", "", "", f"{play.percent}%", play.semester])
 
         # Throw 404 when there is no data found
         if len(data) == 0:
@@ -206,7 +199,7 @@ class PlayDataExporterService:
     # Prepare data log zip file
     @staticmethod
     def _export_full_event_log(
-        instance: WidgetInstance, semesters: list[str], is_student: bool
+        instance: WidgetInstance, logs: QuerySet[LogPlay]
     ) -> tuple[bytes, str]:
         headers = [
             "User ID",
@@ -223,40 +216,33 @@ class PlayDataExporterService:
         ]
         play_log_data = []
 
-        # For each semester, get all play logs
-        for semester in semesters:
-            [year, term] = semester.split("-")
-            logs = PlayDataExporterService.get_all_plays_for_instance(
-                instance, term, int(year), is_student
-            )
+        # For each play log, process its data and add to results
+        for play in logs:
+            # If there is no username, it is a guest user
+            username = play.user.id if play.user else "(Guest)"
 
-            # For each play log, process its data and add to results
-            for play in logs:
-                # If there is no username, it is a guest user
-                username = play.user.id if play.user else "(Guest)"
-
-                # Get and then process each log
-                play_events = play.get_logs()
-                for play_event in play_events:
-                    last, first = (
-                        (play.user.last_name, play.user.first_name)
-                        if play.user
-                        else ("", "")
-                    )
-                    row = [
-                        username,
-                        last,
-                        first,
-                        play.id,
-                        semester,
-                        play_event.log_type,
-                        play_event.item_id,
-                        play_event.text,
-                        play_event.value,
-                        play_event.game_time,
-                        play_event.created_at,
-                    ]
-                    play_log_data.append(row)
+            # Get and then process each log
+            play_events = play.get_logs()
+            for play_event in play_events:
+                last, first = (
+                    (play.user.last_name, play.user.first_name)
+                    if play.user
+                    else ("", "")
+                )
+                row = [
+                    username,
+                    last,
+                    first,
+                    play.id,
+                    play.semester,
+                    play_event.log_type,
+                    play_event.item_id,
+                    play_event.text,
+                    play_event.value,
+                    play_event.game_time,
+                    play_event.created_at,
+                ]
+                play_log_data.append(row)
 
         # Throw 404 if no logs found
         if len(play_log_data) == 0:
@@ -363,39 +349,25 @@ class PlayDataExporterService:
     # Outputs a .zip file of two CSV files for individual and collective referrers data
     @staticmethod
     def _export_referrer_urls(
-        instance: WidgetInstance, semesters: list[str], is_student: bool
+        instance: WidgetInstance, logs: QuerySet[LogPlay]
     ) -> tuple[bytes, str]:
         headers_individual = ["User", "URL", "Date"]
         data_individual = []
         referrer_count = {}
 
-        for semester in semesters:
-            # Get date object
-            [year, term] = semester.split("-")
-            date = DateRange.objects.filter(semester=term, year=year).first()
-            if date is None:
-                raise MsgNotFound(msg="Semester not found")
+        # Process data for each individual play and their referrer
+        for play in logs:
+            url = play.referrer_url if play.referrer_url else instance.play_url
+            user_id = play.user.id if play.user else "(Guest)"
+            data_individual.append([user_id, url, play.created_at])
 
-            # Form query, only including user info if requesting user isn't a student
-            raw_data = PlayDataExporterService.get_all_plays_for_instance(
-                instance, term, int(year), is_student
-            )
-            if len(raw_data) == 0:
-                raise MsgNotFound(msg="No play logs found")
-
-            # Process data for each individual play and their referrer
-            for datum in raw_data:
-                url = datum.referrer_url if datum.referrer_url else instance.play_url
-                user_id = datum.user.id if datum.user else "(Guest)"
-                data_individual.append([user_id, url, datum.created_at])
-
-            # Count collective number of times a URL appears
-            for datum in raw_data:
-                url = datum.referrer_url if datum.referrer_url else instance.play_url
-                if url not in referrer_count:
-                    referrer_count[url] = 0
-                else:
-                    referrer_count[url] += 1
+        # Count collective number of times a URL appears
+        for datum in logs:
+            url = datum.referrer_url if datum.referrer_url else instance.play_url
+            if url not in referrer_count:
+                referrer_count[url] = 0
+            else:
+                referrer_count[url] += 1
 
         # Build all individual data into a CSV
         csv_individual = PlayDataExporterService.build_csv(
@@ -420,9 +392,7 @@ class PlayDataExporterService:
         return zip_buffer.getvalue(), "zip"
 
     @staticmethod
-    def _export_questions_and_answers(
-        instance: WidgetInstance, semesters: list[str]
-    ) -> tuple[str, str]:
+    def _export_questions_and_answers(instance: WidgetInstance) -> tuple[str, str]:
         question_rows = instance.get_latest_qset().get_questions()
 
         headers = ["Question", "Answers"]
@@ -461,33 +431,6 @@ class PlayDataExporterService:
             # Combine all cells in the row with commas
             csv += ",".join(row) + "\r\n"
         return csv
-
-    # Build on top of WidgetInstance's get_play_logs method, adds caching and allows filtering out user info
-    @staticmethod
-    def get_all_plays_for_instance(
-        instance: WidgetInstance | str,
-        semester: str = "all",
-        year: str = "all",
-        is_student: bool = False,
-    ) -> list[LogPlay]:
-        # Get cached copy
-        cache_key = f"play-logs.{instance.id if isinstance(instance, WidgetInstance) else instance}.{semester}-{year}"
-        plays = cache.get(cache_key, None)
-
-        # Cache miss, get play logs
-        if plays is None:
-            plays = instance.get_play_logs(semester=semester, year=year)
-
-        # Erase user from log if the requesting user is student
-        if is_student:
-            for play in plays:
-                play.user_id = None
-                play.user = None
-
-        # Store result to cache, return
-        result = list(plays)
-        cache.set(cache_key, result, settings.PLAYDATA_EXPORTER_CACHE_TIMEOUT)
-        return result
 
     @staticmethod
     def _sanitize_text(text):


### PR DESCRIPTION
Resolves #313:

- Adds additional queryset filtering in the `play-sessions` API when using the `?inst_id` query param. User access is appropriately checked and the queryset is filtered by provisional access if needed.
- Added extra model instance method for `WidgetInstance` to grab a filtered `LogPlay` queryset based on provisional access.
- Reworked the playdata export endpoint for the `widget-instance` API to pass a preprocessed set of logs to the playdata exporter service, instead of requiring the export service to fetch the logs directly.
- Reworked method signature for playdata exporter methods to utilize the preprocessed logs.
- Added fallback handling for custom widget playdata exporters in case they are using the old method signature.
- Updated tests.

Additional edits:
- Creates a `MateriaTestCase` class that performs global DB setup tasks for the test suite. This includes group creation (`basic_author`, `support_user`, `no_author`) and `DateRange` population. The other test suits inherit this base test case, and the manual DB population steps have been removed.